### PR TITLE
fix: correct naming of neutral-background-color-default

### DIFF
--- a/src/color-alias.json
+++ b/src/color-alias.json
@@ -60,7 +60,7 @@
     "value": "{black}"
   },
 
-  "neutral-content-color": {
+  "neutral-content-color-default": {
     "value": "{gray-800}"
   },
   "neutral-content-color-hover": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Should have had `-default`