### PR TITLE
fix: correct typo that was breaking the build

### DIFF
--- a/src/color-alias.json
+++ b/src/color-alias.json
@@ -457,7 +457,7 @@
         "value": "{positive-color-1000}"
       },
       "dark": {
-        "value": "positivee-color-400}"
+        "value": "{positive-color-400}"
       },
       "darkest": {
         "value": "{positive-color-500}"
@@ -476,7 +476,7 @@
         "value": "{positive-color-300}"
       },
       "darkest": {
-        "value": "positivee-color-400}"
+        "value": "{positive-color-400}"
       },
       "wireframe": {
         "value": "{positive-color-1100}"


### PR DESCRIPTION
## Description

Fixes typo introduced in #23 that was breaking the build in CSS.

We should have tests for this.