### PR TITLE
fix: radio-button-selection-indicator was missing

### DIFF
--- a/src/component-layout.json
+++ b/src/component-layout.json
@@ -546,6 +546,10 @@
       }
     }
   },
+  
+  "radio-button-selection-indicator": {
+    "value": "4px"
+  },
 
   "status-light-dot-size-small": {
     "sets": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

radio-button-selection-indicator was missing

## Related Issue
DNA-1156


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
