### PR TITLE
fix: drover parser setting colors to wireframe

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3737,9 +3737,9 @@ strip-json-comments@~2.0.1:
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 style-dictionary-sets@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-2.0.0.tgz#a8d45430a3002c99bc16f6c2ca91e1292f50ff40"
-  integrity sha512-StEAHtgMZNakY5SN/3q+rgVgkRtYdjoyYlxD1H5JSgdaIG0bd3Qyxw02meEHoLgotoMY0ojoRqsMzwy/VJLIWQ==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-2.0.1.tgz#82d8ff887c00b49c4ff5bf2357fa3e378923274b"
+  integrity sha512-2WLFqkY/iEvPbsQQB89JyPOPbYWeunjTBR34LcV8bxdC6T46MOGnW9aOaHPKTxY7ZAYiVNxWQoaa1TwNiaJ5Sg==
   dependencies:
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The style-dictionary-sets parser for drover was setting color tokens to wireframe.  This updates the dependency to pick up that patch (2.0.1).

<!--- Describe your changes in detail -->

## Related Issue
I didn't open an issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I like fixing things
<!--- Why is this change required? What problem does it solve? -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
