### PR TITLE
chore: added a thing to diff last release dist with local

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "config.js",
   "scripts": {
     "build": "style-dictionary build",
+    "diffLastRelease": ". tasks/diffOutput.sh",
     "clean": "rm -rf dist",
     "pre-commit": "lint-staged",
     "prepare": "husky install && yarn run build",

--- a/tasks/diffOutput.sh
+++ b/tasks/diffOutput.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# test for a target dist file to look for
+if [ -z "$1" ]
+then
+  echo "No dist file type was specified, default to variables.json"
+  fetchType='variables'
+else
+  fetchType=$1
+fi
+
+# set up what we want to look for
+lastRelease=`npm show @adobe/spectrum-tokens@beta version`
+fetchTarget="@adobe/spectrum-tokens@$lastRelease/dist/json/$fetchType.json"
+
+echo "Attempting to fetch and diff $fetchTarget"
+
+# clean up the last run
+rm .tmp/old-$fetchType.json
+
+# grab the unpackage for the version we asked for
+fetchURL="https://unpkg.com/$fetchTarget"
+curl --silent -o .tmp/old-$fetchType.json $fetchURL
+
+# git diff is pretty
+git diff --no-index .tmp/old-$fetchType.json dist/json/$fetchType.json
+
+# diff sends 1 if there are differences, the script thinks it had an error# 
+# this just catches the code and stuffs it if there's actually a diff
+exit_code=$?
+
+if [ $exit_code == 0 ]
+then  
+  echo "No difference found."
+fi
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a tool that will diff either `variables.json` or `drover.json` against the last package published.  Hacky a bit because it relies on the `unpkg` CDN, not fiddling about with git tags etc.  But it works.



## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
