### PR TITLE
fix: switch tooltip-width and height to tooltip-tip-width

### DIFF
--- a/src/component-layout.json
+++ b/src/component-layout.json
@@ -1699,7 +1699,7 @@
       }
     }
   },
-  "tooltip-width": {
+  "tooltip-tip-width": {
     "sets": {
       "desktop": {
         "value": "8px"
@@ -1709,7 +1709,7 @@
       }
     }
   },
-  "tooltip-height": {
+  "tooltip-tip-height": {
     "sets": {
       "desktop": {
         "value": "4px"


### PR DESCRIPTION
## Description

from Cable Hicks:

> `tooltip-width` and `tooltip-height` should be `tooltip-tip-width` and `tooltip-tip-height` according to the specs.

The token `tooltip-maximum-width` does not have a name update change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
