### PR TITLE
chore: add deprecateExpress task

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "buildManifest": "node tasks/buildManifest.js",
     "convert-excel": "node tasks/excel.js",
-    "test": "yarn node --experimental-vm-modules $(yarn bin jest)",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
     "test-watch": "jest --runInBand --watch",
     "build": "node tasks/buildSpectrumTokens.js",
     "diffLastRelease": ". tasks/diffOutput.sh",

--- a/tasks/deprecateExpress.js
+++ b/tasks/deprecateExpress.js
@@ -1,0 +1,11 @@
+import glob from "glob-promise";
+import { readFile, writeFile } from "fs/promises";
+import { augmentExpressTokens } from "./lib/augmentExpressTokens.js";
+
+const files = await glob("src/**/*.json");
+files.forEach(async (fileName) => {
+  const fileTokens = JSON.parse(await readFile(fileName, "utf8"));
+  const result = augmentExpressTokens(fileTokens);
+  await writeFile(fileName, JSON.stringify(result, null, 2));
+  console.log(`Updated ${fileName}.`);
+});

--- a/tasks/lib/augmentExpressTokens.js
+++ b/tasks/lib/augmentExpressTokens.js
@@ -1,0 +1,40 @@
+const deprecationObj = {
+  deprecated: true,
+  deprecated_comment:
+    "Express will merge with Spectrum with the release of Spectrum 2.",
+};
+
+const findExpressValue = (tokenObj) => {
+  if (typeof tokenObj === "object" && tokenObj !== null) {
+    if (tokenObj.hasOwnProperty("value")) {
+      return {
+        ...tokenObj,
+        ...deprecationObj,
+      };
+    } else {
+      const result = {};
+      Object.keys(tokenObj).forEach((tokenName) => {
+        result[tokenName] = findExpressValue(tokenObj[tokenName]);
+      });
+      return result;
+    }
+  }
+};
+
+const augmentExpressTokens = (tokenObj) => {
+  if (typeof tokenObj === "object" && tokenObj !== null) {
+    const result = {};
+    Object.keys(tokenObj).forEach((tokenName) => {
+      if (tokenName === "express") {
+        result[tokenName] = findExpressValue(tokenObj[tokenName]);
+      } else {
+        result[tokenName] = augmentExpressTokens(tokenObj[tokenName]);
+      }
+    });
+    return result;
+  } else {
+    return tokenObj;
+  }
+};
+
+export default augmentExpressTokens;

--- a/test/__snapshots__/deprecateExpress.test.js.snap
+++ b/test/__snapshots__/deprecateExpress.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Deprecate Express should add deprecation metadata to Express tokens 1`] = `
+{
+  "corner-radius-100": {
+    "sets": {
+      "express": {
+        "sets": {
+          "desktop": {
+            "deprecated": true,
+            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
+            "value": "6px",
+          },
+          "mobile": {
+            "deprecated": true,
+            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
+            "value": "8px",
+          },
+        },
+      },
+      "spectrum": {
+        "sets": {
+          "desktop": {
+            "value": "4px",
+          },
+          "mobile": {
+            "value": "5px",
+          },
+        },
+      },
+    },
+  },
+  "foo": {
+    "express": {
+      "deprecated": true,
+      "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
+      "value": "bar",
+    },
+  },
+}
+`;

--- a/test/deprecateExpress.test.js
+++ b/test/deprecateExpress.test.js
@@ -1,0 +1,37 @@
+import augmentExpressTokens from "../tasks/lib/augmentExpressTokens.js";
+
+const fixture = {
+  "foo": {
+    "express": {
+      "value": "bar",
+    }
+  },
+  "corner-radius-100": {
+    sets: {
+      spectrum: {
+        sets: {
+          desktop: {
+            value: "4px",
+          },
+          mobile: {
+            value: "5px",
+          },
+        },
+      },
+      express: {
+        sets: {
+          desktop: {
+            value: "6px",
+          },
+          mobile: {
+            value: "8px",
+          },
+        },
+      },
+    },
+  },
+};
+
+test("Deprecate Express should add deprecation metadata to Express tokens", () => {
+  expect(augmentExpressTokens(fixture)).toMatchSnapshot();
+});


### PR DESCRIPTION
## Description

Added a task that augments all the express tokens with deprecation metadata:

```json
{
  "deprecated": true,
  "deprecated_comment":
    "Express will merge with Spectrum with the release of Spectrum 2.",
}
```

## Motivation and Context

Express and Spectrum sets will converge in Spectrum 2 with the exception of a couple of alias tokens that we will provide as CSS custom property overrides rather than storing them in the token system.

## How Has This Been Tested?

I added some tests to verify it is only adding data on the express tokens.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
