### PR TITLE
fix: add 'px' to zero length value in combobox token

### DIFF
--- a/src/layout-component.json
+++ b/src/layout-component.json
@@ -2386,7 +2386,7 @@
   },
   "combo-box-visual-to-field-button-quiet": {
     "component": "combo-box",
-    "value": "0"
+    "value": "0px"
   },
   "thumbnail-size-50": {
     "component": "thumbnail",


### PR DESCRIPTION
## Description

This length value for token `combo-box-visual-to-field-button-quiet` is currently `0`, instead of `0px`, which throws off some CSS calc() results, making them invalid (or requires multiplying this token by 1px).

This fix makes this value consistent with the rest of the token values in the repo, which all specify 0 length values as `0px`. The only other `0` within tokens is for an opacity (which is okay).

## Motivation and Context

I am currently working on the core token migration for the Combobox component in spectrum-css, which is using this token. It currently required multiplying it by 1px in the calc as a workaround. Adding or subtracting `0` instead of `0px` in a CSS calc() [is invalid](https://developer.mozilla.org/en-US/docs/Web/CSS/calc#notes) and gives unexpected results. This change would allow removal of the workaround and would have this value follow the format of the other 0px values used in other tokens.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.