### PR TITLE
Added new floating action button tokens, closes DNA-1283

### DIFF
--- a/.changeset/rotten-oranges-mate.md
+++ b/.changeset/rotten-oranges-mate.md
@@ -1,0 +1,9 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Adding a couple tokens to floating action button that should have been included earlier.
+
+*Tokens added (2):*
+  - `floating-action-button-drop-shadow-y`
+  - `floating-action-button-shadow-color`

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -151,5 +151,9 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
       }
     }
+  },
+  "floating-action-button-shadow-color": {
+    "component": "floating-action-button",
+    "value": "{transparent-black-300}"
   }
 }

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -3124,6 +3124,10 @@
     "component": "floating-action-button",
     "value": "12px"
   },
+  "floating-action-button-drop-shadow-y": {
+    "component": "floating-action-button",
+    "value": "4px"
+  },
   "illustrated-message-maximum-width": {
     "component": "illustrated-message",
     "value": "380px"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

*Tokens added (2):*

  - `floating-action-button-drop-shadow-y`
  - `floating-action-button-shadow-color`

## Related Issue

[DNA-1283](https://jira.corp.adobe.com/browse/DNA-1283)

## Motivation and Context

Adding a couple tokens to floating action button that should have been included earlier.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.