### PR TITLE
Update color loupe and color handle

### DIFF
--- a/.changeset/tricky-bears-grow.md
+++ b/.changeset/tricky-bears-grow.md
@@ -1,0 +1,17 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Removed express specific token data for color loupe and color handle
+
+*Tokens values updated (7):*
+  - `color-handle-drop-shadow-blur`
+  - `color-handle-drop-shadow-x`
+  - `color-handle-drop-shadow-y`
+  - `color-handle-outer-border-opacity`
+  - `color-handle-outer-border-width`
+  - `color-handle-size`
+  - `color-handle-size-key-focus`
+
+*Newly deprecated tokens (1):*
+  - `color-handle-drop-shadow-color`

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -136,19 +136,15 @@
   },
   "color-handle-outer-border-opacity": {
     "component": "color-handle",
-    "sets": {
-      "spectrum": {
-        "value": "{color-handle-inner-border-opacity}"
-      }
-    }
+    "value": "{color-handle-inner-border-opacity}"
   },
   "color-handle-drop-shadow-color": {
     "component": "color-handle",
+    "deprecated": true,
+    "deprecated_comment": "Express does not need a separate design for Color loupe and Color handle components",
     "sets": {
       "express": {
-        "value": "{drop-shadow-color}",
-        "deprecated": true,
-        "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
+        "value": "{drop-shadow-color}"
       }
     }
   },

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -3717,58 +3717,22 @@
   "color-handle-size": {
     "component": "color-handle",
     "sets": {
-      "spectrum": {
-        "sets": {
-          "desktop": {
-            "value": "16px"
-          },
-          "mobile": {
-            "value": "20px"
-          }
-        }
+      "desktop": {
+        "value": "16px"
       },
-      "express": {
-        "sets": {
-          "desktop": {
-            "value": "20px",
-            "deprecated": true,
-            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-          },
-          "mobile": {
-            "value": "24px",
-            "deprecated": true,
-            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-          }
-        }
+      "mobile": {
+        "value": "20px"
       }
     }
   },
   "color-handle-size-key-focus": {
     "component": "color-handle",
     "sets": {
-      "spectrum": {
-        "sets": {
-          "desktop": {
-            "value": "32px"
-          },
-          "mobile": {
-            "value": "40px"
-          }
-        }
+      "desktop": {
+        "value": "32px"
       },
-      "express": {
-        "sets": {
-          "desktop": {
-            "value": "40px",
-            "deprecated": true,
-            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-          },
-          "mobile": {
-            "value": "48px",
-            "deprecated": true,
-            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-          }
-        }
+      "mobile": {
+        "value": "40px"
       }
     }
   },
@@ -3782,55 +3746,19 @@
   },
   "color-handle-outer-border-width": {
     "component": "color-handle",
-    "sets": {
-      "spectrum": {
-        "value": "1px"
-      },
-      "express": {
-        "value": "0px",
-        "deprecated": true,
-        "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-      }
-    }
+    "value": "1px"
   },
   "color-handle-drop-shadow-x": {
     "component": "color-handle",
-    "sets": {
-      "spectrum": {
-        "value": "0"
-      },
-      "express": {
-        "value": "{drop-shadow-x}",
-        "deprecated": true,
-        "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-      }
-    }
+    "value": "0"
   },
   "color-handle-drop-shadow-y": {
     "component": "color-handle",
-    "sets": {
-      "spectrum": {
-        "value": "0"
-      },
-      "express": {
-        "value": "{color-loupe-drop-shadow-y}",
-        "deprecated": true,
-        "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-      }
-    }
+    "value": "0"
   },
   "color-handle-drop-shadow-blur": {
     "component": "color-handle",
-    "sets": {
-      "spectrum": {
-        "value": "0"
-      },
-      "express": {
-        "value": "{color-loupe-drop-shadow-blur}",
-        "deprecated": true,
-        "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-      }
-    }
+    "value": "0"
   },
   "side-navigation-width": {
     "component": "side-navigation",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed express specific token data for color handle and color loupe.

*Tokens values updated (7):*
  - `color-handle-drop-shadow-blur`
  - `color-handle-drop-shadow-x`
  - `color-handle-drop-shadow-y`
  - `color-handle-outer-border-opacity`
  - `color-handle-outer-border-width`
  - `color-handle-size`
  - `color-handle-size-key-focus`

*Newly deprecated tokens (1):*
  - `color-handle-drop-shadow-color`

## Related Issue

[DNA-1279](https://jira.corp.adobe.com/browse/DNA-1279)

## Motivation and Context

Adobe Express does not need a separate design for Color loupe and Color handle components. They will be using the Spectrum component instead. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.