### PR TITLE
Removed express specific token data for color handle

### DIFF
--- a/.changeset/odd-planets-sell.md
+++ b/.changeset/odd-planets-sell.md
@@ -1,0 +1,5 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Removed express specific token data for color handle

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -3193,60 +3193,15 @@
   },
   "color-loupe-height": {
     "component": "color-loupe",
-    "sets": {
-      "spectrum": {
-        "value": "64px"
-      },
-      "express": {
-        "sets": {
-          "desktop": {
-            "value": "40px",
-            "deprecated": true,
-            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-          },
-          "mobile": {
-            "value": "50px",
-            "deprecated": true,
-            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-          }
-        }
-      }
-    }
+    "value": "64px"
   },
   "color-loupe-width": {
     "component": "color-loupe",
-    "sets": {
-      "spectrum": {
-        "value": "48px"
-      },
-      "express": {
-        "sets": {
-          "desktop": {
-            "value": "32px",
-            "deprecated": true,
-            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-          },
-          "mobile": {
-            "value": "40px",
-            "deprecated": true,
-            "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-          }
-        }
-      }
-    }
+    "value": "48px"
   },
   "color-loupe-bottom-to-color-handle": {
     "component": "color-loupe",
-    "sets": {
-      "spectrum": {
-        "value": "12px"
-      },
-      "express": {
-        "value": "6px",
-        "deprecated": true,
-        "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-      }
-    }
+    "value": "12px"
   },
   "color-loupe-outer-border-width": {
     "component": "color-loupe",
@@ -3254,16 +3209,7 @@
   },
   "color-loupe-inner-border-width": {
     "component": "color-loupe",
-    "sets": {
-      "spectrum": {
-        "value": "{border-width-200}"
-      },
-      "express": {
-        "value": "3px",
-        "deprecated": true,
-        "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-      }
-    }
+    "value": "1px"
   },
   "card-minimum-width": {
     "component": "cards",


### PR DESCRIPTION
## Description

These tokens updated were missed in https://github.com/adobe/spectrum-tokens/commit/853d8c36569f800284d6c9f7ce7a49ec6dc2eb99 and so they didn't get released with [@adobe/spectrum-tokens@12.6.0](https://github.com/adobe/spectrum-tokens/releases/tag/%40adobe%2Fspectrum-tokens%4012.6.0)

## Related Issue

[DNA-1279](https://jira.corp.adobe.com/browse/DNA-1279)

## Motivation and Context

:art:  Design changes:
Express will be using Spectrum Color loupe - no specific differences between the two themes for this component anymore.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Token value change

*Token values updated (4):*
  - `color-loupe-bottom-to-color-handle` (removed express specific token data)
  - `color-loupe-height` (removed express specific token data)
  - `color-loupe-inner-border-width` (removed express specific token data)
  - `color-loupe-width` (removed express specific token data)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.