### PR TITLE
Updated color-handle remove express specific value

### DIFF
--- a/.changeset/tough-waves-drive.md
+++ b/.changeset/tough-waves-drive.md
@@ -1,0 +1,11 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Updated color-handle-inner-border-opacity to remove express specific value
+
+## Token Diff
+
+*Token values updated (2):*
+  - `color-handle-inner-border-opacity` (to remove express specific values)
+  - `color-handle-outer-border-opacity` (to remove express specific values)

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -115,16 +115,7 @@
   },
   "color-handle-inner-border-opacity": {
     "component": "color-handle",
-    "sets": {
-      "spectrum": {
-        "value": "0.42"
-      },
-      "express": {
-        "value": "0.15",
-        "deprecated": true,
-        "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2."
-      }
-    }
+    "value": "0.42"
   },
   "color-handle-outer-border-color": {
     "component": "color-handle",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

[DNA-1279](https://jira.corp.adobe.com/browse/DNA-1279)

## Motivation and Context

Adobe Express does not need a separate design for Color loupe and Color handle components. They will be using the Spectrum component instead.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.