### PR TITLE
fix(tokens): typo for coachmark in component field

### DIFF
--- a/.changeset/lazy-pans-give.md
+++ b/.changeset/lazy-pans-give.md
@@ -1,0 +1,19 @@
+---
+"@adobe/spectrum-tokens": patch
+---
+
+Fixed component name typo
+
+## Token Diff
+
+The following tokens have update `component` metadata property (all have been set to `coach-mark`):
+
+* `coach-mark-minimum-width`
+* `coach-mark-edge-to-content`
+* `coach-mark-pagination-text-to-bottom-edge`
+* `coach-mark-width`
+* `coach-mark-media-minimum-height`
+* `coach-mark-media-height`
+* `coach-mark-title-size`
+* `coach-mark-body-size`
+* `coach-mark-pagination-body-size`

--- a/.github/workflows/deploy-visualizer.yml
+++ b/.github/workflows/deploy-visualizer.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.3.1
+          version: 8.6.1
       - uses: moonrepo/setup-moon-action@v1
       - run: moon setup
       - run: moon run visualizer:build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.3.1
+          version: 8.6.1
       - uses: moonrepo/setup-moon-action@v1
       - run: moon setup
       - run: moon run :build

--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -18,7 +18,7 @@ node:
 
   # The version of the package manager (above) to use.
   pnpm:
-    version: "8.3.1"
+    version: "8.6.1"
 
   # Add `node.version` as a constraint in the root `package.json` `engines`.
   addEnginesConstraint: true

--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
   "engines": {
     "node": "18.13.0"
   },
-  "packageManager": "pnpm@8.3.1"
+  "packageManager": "pnpm@8.6.1"
 }

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -3252,7 +3252,7 @@
     "value": "{illustrated-message-body-size}"
   },
   "coach-mark-minimum-width": {
-    "component": "coach-mark-width",
+    "component": "coach-mark",
     "sets": {
       "desktop": {
         "value": "296px"
@@ -3263,7 +3263,7 @@
     }
   },
   "coach-mark-edge-to-content": {
-    "component": "coach-mark-width",
+    "component": "coach-mark",
     "sets": {
       "desktop": {
         "value": "{spacing-400}"
@@ -3274,7 +3274,7 @@
     }
   },
   "coach-mark-pagination-text-to-bottom-edge": {
-    "component": "coach-mark-width",
+    "component": "coach-mark",
     "sets": {
       "desktop": {
         "value": "33px"
@@ -3285,7 +3285,7 @@
     }
   },
   "coach-mark-media-minimum-height": {
-    "component": "coach-mark-media-height",
+    "component": "coach-mark",
     "sets": {
       "desktop": {
         "value": "166px"
@@ -3296,7 +3296,7 @@
     }
   },
   "coach-mark-title-size": {
-    "component": "coach-mark-media-height",
+    "component": "coach-mark",
     "sets": {
       "mobile": {
         "value": "{heading-size-xxs}"
@@ -3304,7 +3304,7 @@
     }
   },
   "coach-mark-body-size": {
-    "component": "coach-mark-media-height",
+    "component": "coach-mark",
     "sets": {
       "mobile": {
         "value": "{body-size-xs}"
@@ -3312,7 +3312,7 @@
     }
   },
   "coach-mark-pagination-body-size": {
-    "component": "coach-mark-media-height",
+    "component": "coach-mark",
     "sets": {
       "mobile": {
         "value": "{body-size-xs}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 


### PR DESCRIPTION
## Description

The `component` name field had some typos in the coach mark component; this pr fixes them.

The tokens with updated `component` metadata (all set to "coach-mark"):

* `coach-mark-minimum-width`
* `coach-mark-edge-to-content`
* `coach-mark-pagination-text-to-bottom-edge`
* `coach-mark-width`
* `coach-mark-media-minimum-height`
* `coach-mark-media-height`
* `coach-mark-title-size`
* `coach-mark-body-size`
* `coach-mark-pagination-body-size`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.