### PR TITLE
Fix token typo

### DIFF
--- a/.changeset/proud-pants-burn.md
+++ b/.changeset/proud-pants-burn.md
@@ -1,0 +1,15 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Fixed typo with `picker-end-edge-to-disclosure-icon-quiet` by adding a new token and deprecating `picker-end-edge-to-disclousure-icon-quiet`.
+
+## Token Diff
+
+_Token added (1):_
+
+* `picker-end-edge-to-disclosure-icon-quiet`
+
+_Newly deprecated token (1):_
+
+* `picker-end-edge-to-disclousure-icon-quiet`

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -2744,8 +2744,15 @@
   },
   "picker-end-edge-to-disclousure-icon-quiet": {
     "component": "picker",
-    "value": "0px",
+    "value": "{picker-end-edge-to-disclosure-icon-quiet}",
+    "deprecated": true,
+    "deprecated_comment": "Use `picker-end-edge-to-disclosure-icon-quiet` instead",
     "uuid": "c8bd227d-c72b-4f6a-9d93-0b595821dee0"
+  },
+  "picker-end-edge-to-disclosure-icon-quiet": {
+    "component": "picker",
+    "value": "0px",
+    "uuid": "03da68d8-cd87-4e29-9aaf-ab467594ec2b"
   },
   "text-field-minimum-width-multiplier": {
     "component": "text-field",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed typo with `picker-end-edge-to-disclosure-icon-quiet` by adding a new token and deprecating `picker-end-edge-to-disclousure-icon-quiet`.

## Token Diff

_Token added (1):_

* `picker-end-edge-to-disclosure-icon-quiet`

_Newly deprecated token (1):_

* `picker-end-edge-to-disclousure-icon-quiet`

## Motivation and Context

@karstens pointed out the spelling error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.