### PR TITLE
Renamed meter-default-width to meter-width

### DIFF
--- a/.changeset/strong-tables-cheer.md
+++ b/.changeset/strong-tables-cheer.md
@@ -1,0 +1,19 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Update meter token from meter-default-width to meter-width.
+
+### Design motivation
+
+We try to avoid "default" in the name (unless it's the state) because it's a word that implies that it's relative to something else that may not be named, which could get confusing. So meter-width I think for the name, and then just add a note in the specs.
+
+### Token diff
+
+_Renamed token:_
+
+- `meter-default-width` -> `meter-width`
+
+_Token added for deprecation and rename:_
+
+- `meter-default-width`

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -1744,7 +1744,7 @@
     "value": "768px",
     "uuid": "63bfb4da-4aaf-49c6-9328-16c636cf0bf9"
   },
-  "meter-default-width": {
+  "meter-width": {
     "component": "meter",
     "sets": {
       "desktop": {
@@ -1756,6 +1756,13 @@
         "uuid": "dc5f4966-4ddd-4e9a-a748-370d8eaae568"
       }
     }
+  },
+  "meter-default-width": {
+    "component": "meter",
+    "value": "{meter-width}",
+    "deprecated": true,
+    "deprecated_comment": "Token renamed, use `meter-width`",
+    "uuid": "2633d29d-8a14-48e8-977c-bdb9a53b3bd5"
   },
   "meter-thickness-small": {
     "component": "meter",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Renamed `meter-default-width` to `meter-width`

## Related Issue

[DNA-1297](https://jira.corp.adobe.com/browse/DNA-1297)

## Motivation and Context

> We try to avoid "default" in the name (unless it's the state) because it's a word that implies that it's relative to something else that may not be named, which could get confusing. So meter-width I think for the name, and then just add a note in the specs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
