### PR TITLE
Missing `wireframe` values

### DIFF
--- a/.changeset/olive-feet-fetch.md
+++ b/.changeset/olive-feet-fetch.md
@@ -1,0 +1,12 @@
+---
+"@adobe/spectrum-tokens": patch
+---
+
+Added missing `wireframe` values for 2 color tokens
+
+## Token Diff
+
+_Tokens update (2):_
+
+- `opacity-checkerboard-square-dark`
+- `overlay-opacity`

--- a/packages/tokens/src/color-aliases.json
+++ b/packages/tokens/src/color-aliases.json
@@ -28,6 +28,10 @@
       "darkest": {
         "value": "0.6",
         "uuid": "31d5b502-6266-4309-8f8a-3892e6e158da"
+      },
+      "wireframe": {
+        "value": "0.4",
+        "uuid": "93b904da-5d1f-4fd9-aa26-5aabe19df108"
       }
     }
   },

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -53,6 +53,10 @@
       "darkest": {
         "value": "{gray-800}",
         "uuid": "f783b8cb-d31f-46c2-b550-990639752510"
+      },
+      "wireframe": {
+        "value": "{gray-200}",
+        "uuid": "e7fe88a4-6ab3-4963-8f10-9908a5a83123"
       }
     }
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added `wireframe` values to 2 color tokens.

_Tokens update (2):_

- `opacity-checkerboard-square-dark`
- `overlay-opacity`

## Motivation and Context

Running some tests, I found 2 color tokens were missing `wireframe` values in the sets.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
