### PR TITLE
fix: rgb used instead of rgba for a couple tokens

### DIFF
--- a/.changeset/warm-experts-beg.md
+++ b/.changeset/warm-experts-beg.md
@@ -1,0 +1,5 @@
+---
+"@adobe/spectrum-tokens": patch
+---
+
+fix: rgb used instead of rgba for a couple tokens

--- a/packages/tokens/src/color-palette.json
+++ b/packages/tokens/src/color-palette.json
@@ -48,7 +48,7 @@
     "uuid": "b85836bf-af47-412a-900a-4ec5ad0733b2"
   },
   "transparent-white-900": {
-    "value": "rgb(255, 255, 255, 0.94)",
+    "value": "rgba(255, 255, 255, 0.94)",
     "uuid": "c5c823c6-1911-4e0e-ba2f-5105f467e108"
   },
   "transparent-white-1000": {
@@ -104,7 +104,7 @@
     "uuid": "3e89f180-b0f0-4de0-904b-c80f0210a361"
   },
   "transparent-black-900": {
-    "value": "rgb(0, 0, 0, 0.93)",
+    "value": "rgba(0, 0, 0, 0.93)",
     "uuid": "c0a331f9-53e3-4c72-b5e3-139d730a1752"
   },
   "transparent-black-1000": {


### PR DESCRIPTION
## Description

transparent-white-900 & transparent-black-900 values where rgb() but have alphas set; should be rgba().

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Data consistency.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
