### PR TITLE
feat: updates from spectrum-tokens-studio-data

### DIFF
--- a/.changeset/brown-years-perform.md
+++ b/.changeset/brown-years-perform.md
@@ -1,0 +1,5 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Adds missing schema information for `corner-radius-1000`. Also added `schemas/token-types/multiplier.json` to the `scale-set` schema.

--- a/packages/tokens/schemas/token-types/scale-set.json
+++ b/packages/tokens/schemas/token-types/scale-set.json
@@ -26,6 +26,9 @@
             },
             {
               "$ref": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json"
+            },
+            {
+              "$ref": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/multiplier.json"
             }
           ]
         },
@@ -39,6 +42,9 @@
             },
             {
               "$ref": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json"
+            },
+            {
+              "$ref": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/multiplier.json"
             }
           ]
         }

--- a/packages/tokens/src/layout.json
+++ b/packages/tokens/src/layout.json
@@ -153,10 +153,12 @@
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
     "sets": {
       "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/multiplier.json",
         "value": "0.5",
         "uuid": "e4ad85b2-97bf-48cf-a5a9-3ff3d1fada5b"
       },
       "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/multiplier.json",
         "value": "0.5",
         "uuid": "9cd69903-8417-4d6a-92cf-7ec759d5f60f"
       }


### PR DESCRIPTION
Created by Action: https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/7658869156

Adds missing schema information. The diff script needed an update to recognize the proper schema for these token values.
