### PR TITLE
Added UUIDs to set tokens

### DIFF
--- a/.changeset/clean-snails-cheer.md
+++ b/.changeset/clean-snails-cheer.md
@@ -1,0 +1,5 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Added UUIDs to the base of set tokens.

--- a/packages/tokens/schemas/token-types/color-set.json
+++ b/packages/tokens/schemas/token-types/color-set.json
@@ -75,5 +75,5 @@
     "deprecated_comment": {},
     "uuid": {}
   },
-  "required": ["sets"]
+  "required": ["sets", "uuid"]
 }

--- a/packages/tokens/schemas/token-types/color-set.json
+++ b/packages/tokens/schemas/token-types/color-set.json
@@ -73,7 +73,11 @@
     "private": {},
     "deprecated": {},
     "deprecated_comment": {},
-    "uuid": {}
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$",
+      "format": "uuid"
+    }
   },
   "required": ["sets", "uuid"]
 }

--- a/packages/tokens/schemas/token-types/scale-set.json
+++ b/packages/tokens/schemas/token-types/scale-set.json
@@ -49,7 +49,11 @@
     "private": {},
     "deprecated": {},
     "deprecated_comment": {},
-    "uuid": {}
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$",
+      "format": "uuid"
+    }
   },
   "required": ["sets", "uuid"]
 }

--- a/packages/tokens/schemas/token-types/scale-set.json
+++ b/packages/tokens/schemas/token-types/scale-set.json
@@ -51,5 +51,5 @@
     "deprecated_comment": {},
     "uuid": {}
   },
-  "required": ["sets"]
+  "required": ["sets", "uuid"]
 }

--- a/packages/tokens/src/color-aliases.json
+++ b/packages/tokens/src/color-aliases.json
@@ -42,7 +42,8 @@
         "value": "0.4",
         "uuid": "93b904da-5d1f-4fd9-aa26-5aabe19df108"
       }
-    }
+    },
+    "uuid": "bc377afe-9055-45f9-8906-9f83ee07dada"
   },
   "drop-shadow-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -67,7 +68,8 @@
         "value": "rgba(0, 0, 0, 0.15)",
         "uuid": "1deef94a-efba-4670-a1be-78ee021bdfe8"
       }
-    }
+    },
+    "uuid": "4467906f-b4e1-48d9-bd5f-cfec4052c47d"
   },
   "opacity-disabled": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
@@ -97,7 +99,8 @@
         "value": "{gray-200}",
         "uuid": "6945b976-83b4-4aec-a687-cb461bc9fe70"
       }
-    }
+    },
+    "uuid": "44807783-e21a-42a9-b880-2cebdaa11e0c"
   },
   "background-layer-1-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -122,7 +125,8 @@
         "value": "{gray-100}",
         "uuid": "3ccfa493-5375-492a-93b0-7418655c3b56"
       }
-    }
+    },
+    "uuid": "b3e813b0-a76f-42b8-98f2-3c8a4090a4c5"
   },
   "background-layer-2-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -147,7 +151,8 @@
         "value": "{gray-50}",
         "uuid": "6556a64d-5944-4d65-a6cc-9c6121044ac7"
       }
-    }
+    },
+    "uuid": "9abdcab8-2ff4-40b2-8d86-5e0a09b8cf88"
   },
   "neutral-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -172,7 +177,8 @@
         "value": "{gray-800}",
         "uuid": "9ff12440-fe4e-4f47-ab43-aea39f9ce6f2"
       }
-    }
+    },
+    "uuid": "0c809329-bfc8-4802-a5f8-feecc0ce6018"
   },
   "neutral-background-color-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -197,7 +203,8 @@
         "value": "{gray-900}",
         "uuid": "b6c12c43-39da-415b-a828-43883dfa212d"
       }
-    }
+    },
+    "uuid": "68fad5b1-bbbe-4337-b98e-bb9b605ea006"
   },
   "neutral-background-color-down": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -222,7 +229,8 @@
         "value": "{gray-900}",
         "uuid": "69c94cbb-b852-4b5c-8e5f-26664dbf083a"
       }
-    }
+    },
+    "uuid": "b25017fb-d8a3-4e90-9f6d-2e1bebdffb10"
   },
   "neutral-background-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -247,7 +255,8 @@
         "value": "{gray-900}",
         "uuid": "83e3eea6-e59e-4aca-8126-a9e984e90b08"
       }
-    }
+    },
+    "uuid": "ddbc3e84-ae77-435b-93e6-da50c7a949e0"
   },
   "neutral-background-color-selected-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -264,7 +273,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "60caae29-d389-421e-a574-b26bcaeed3bf"
       }
-    }
+    },
+    "uuid": "1cd150bf-e900-4581-8952-dcf3e37c5b0a"
   },
   "neutral-background-color-selected-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -281,7 +291,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "0deac090-f00a-4927-880d-dfdca06bd66e"
       }
-    }
+    },
+    "uuid": "48b07514-10c0-49ee-a383-11cc2eceb866"
   },
   "neutral-background-color-selected-down": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -298,7 +309,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "bf3de5f6-665c-4a6a-b238-e767b7240fd8"
       }
-    }
+    },
+    "uuid": "98605fb3-1905-4309-95b9-bdd53e08b341"
   },
   "neutral-background-color-selected-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -315,7 +327,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "e012e155-2220-43e9-a248-61c71e99cc2b"
       }
-    }
+    },
+    "uuid": "d94c6eec-4f22-45e5-a5b3-f91773b99358"
   },
   "neutral-subdued-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -340,7 +353,8 @@
         "value": "{gray-600}",
         "uuid": "7a4f50a8-4e1b-49b4-b94a-6282c63bd5ea"
       }
-    }
+    },
+    "uuid": "46f2e88e-6238-43d9-8632-b8e3e5a4a52d"
   },
   "neutral-subdued-background-color-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -365,7 +379,8 @@
         "value": "{gray-700}",
         "uuid": "0e32d8e6-2f91-4d56-a717-8bfc17c0a2c6"
       }
-    }
+    },
+    "uuid": "12111698-b0d6-49a6-a652-c9f31c67aa61"
   },
   "neutral-subdued-background-color-down": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -390,7 +405,8 @@
         "value": "{gray-800}",
         "uuid": "a4cbab05-1225-45a3-b612-194df4ab85ae"
       }
-    }
+    },
+    "uuid": "8d0018a9-9d83-426c-a757-2923b67db391"
   },
   "neutral-subdued-background-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -415,7 +431,8 @@
         "value": "{gray-700}",
         "uuid": "ea153fd0-f7f2-41ab-8f65-8181b26a939b"
       }
-    }
+    },
+    "uuid": "f26e8e36-183c-4364-94e6-4158b461825b"
   },
   "neutral-subdued-content-color-selected": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
@@ -445,7 +462,8 @@
         "value": "{accent-color-900}",
         "uuid": "ebd98dbc-0949-4fca-8fe1-4cd7d610e7a5"
       }
-    }
+    },
+    "uuid": "1b8286ae-82d5-41e6-a15b-84f2f325094d"
   },
   "accent-background-color-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -470,7 +488,8 @@
         "value": "{accent-color-1000}",
         "uuid": "17ce0649-1b72-4e06-96a3-5137c8688233"
       }
-    }
+    },
+    "uuid": "ca7fdae0-9e35-4c28-8ff2-fb92be1c3155"
   },
   "accent-background-color-down": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -495,7 +514,8 @@
         "value": "{accent-color-1100}",
         "uuid": "8d496041-f129-4794-9d8b-e64bb685b0c1"
       }
-    }
+    },
+    "uuid": "d6c0d9cb-0778-45a2-9c70-8c7e234556df"
   },
   "accent-background-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -520,7 +540,8 @@
         "value": "{accent-color-1000}",
         "uuid": "98781a4d-1bcc-4ede-8d40-37c76e445b3d"
       }
-    }
+    },
+    "uuid": "0a1e74f1-ffc9-4f6a-bed6-f75882e072e7"
   },
   "accent-content-color-selected": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
@@ -550,7 +571,8 @@
         "value": "{informative-color-900}",
         "uuid": "d3fda217-e0cb-4dd8-8d13-a22bcc648f4d"
       }
-    }
+    },
+    "uuid": "f95deae9-0726-4fb5-be41-0680d40439ec"
   },
   "informative-background-color-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -575,7 +597,8 @@
         "value": "{informative-color-1000}",
         "uuid": "5d0b457c-b59e-4cd6-b8c5-fa934e9a56ae"
       }
-    }
+    },
+    "uuid": "8c7a907e-7572-46c1-8a72-42552293510b"
   },
   "informative-background-color-down": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -600,7 +623,8 @@
         "value": "{informative-color-1100}",
         "uuid": "e210cabe-f803-4a46-8da7-e35e003140d6"
       }
-    }
+    },
+    "uuid": "73ad4073-7d38-4e74-947b-7e9d6140663b"
   },
   "informative-background-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -625,7 +649,8 @@
         "value": "{informative-color-1000}",
         "uuid": "1be73e4a-0817-435d-910c-0b0fc1825cbb"
       }
-    }
+    },
+    "uuid": "a6b570d5-3e91-4dff-b706-bf485a137d03"
   },
   "negative-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -650,7 +675,8 @@
         "value": "{negative-color-900}",
         "uuid": "4720ac8b-47ae-443a-b393-89f08a1b52c6"
       }
-    }
+    },
+    "uuid": "dc84d6f1-c287-405a-bb35-352b030d3718"
   },
   "negative-background-color-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -675,7 +701,8 @@
         "value": "{negative-color-1000}",
         "uuid": "8c39a7fc-c904-4cf7-8ccc-be459d1a9c0e"
       }
-    }
+    },
+    "uuid": "81b0e851-9a50-4960-ac8c-e29a04ff7b0d"
   },
   "negative-background-color-down": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -700,7 +727,8 @@
         "value": "{negative-color-1100}",
         "uuid": "da8b206c-6b7c-4994-be3b-6e99e813ad30"
       }
-    }
+    },
+    "uuid": "a88541e5-37e6-4865-a24e-cc319c1c7b62"
   },
   "negative-background-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -725,7 +753,8 @@
         "value": "{negative-color-1000}",
         "uuid": "3791aad5-91cc-4aed-af41-8033afe33bf6"
       }
-    }
+    },
+    "uuid": "4cefc283-c2f0-4199-9fab-40426911023b"
   },
   "positive-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -750,7 +779,8 @@
         "value": "{positive-color-900}",
         "uuid": "87a32594-ddb7-48f8-a322-6dc0b761dc05"
       }
-    }
+    },
+    "uuid": "f237a708-8e19-41bc-a1b5-ce25b68f474f"
   },
   "positive-background-color-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -775,7 +805,8 @@
         "value": "{positive-color-1000}",
         "uuid": "e6572844-3118-460c-824f-b11b82e27180"
       }
-    }
+    },
+    "uuid": "0e986617-aa45-47dc-8b11-139089ea89ac"
   },
   "positive-background-color-down": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -800,7 +831,8 @@
         "value": "{positive-color-1100}",
         "uuid": "18af3356-ca03-4a36-bd15-b59bf11ee776"
       }
-    }
+    },
+    "uuid": "1922ea54-19d8-44d6-97e5-9ab66c0782db"
   },
   "positive-background-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -825,7 +857,8 @@
         "value": "{positive-color-1000}",
         "uuid": "2ca6e211-63f7-4c0e-b089-03905788c7f1"
       }
-    }
+    },
+    "uuid": "0983a44e-7aa9-4b1b-9d1f-4932d0c4a961"
   },
   "notice-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -850,7 +883,8 @@
         "value": "{notice-color-1100}",
         "uuid": "640e857c-c62c-4289-b83a-1e36cee90ad4"
       }
-    }
+    },
+    "uuid": "95bfb862-41e4-40f1-817b-3a236898bb48"
   },
   "disabled-background-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
@@ -890,7 +924,8 @@
         "value": "{gray-600}",
         "uuid": "6a74ab0a-e481-4d38-9db7-ea8ef885940b"
       }
-    }
+    },
+    "uuid": "f76e86c1-02ef-447f-97d2-8dbaf0d1b03c"
   },
   "red-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -915,7 +950,8 @@
         "value": "{red-1100}",
         "uuid": "4b943658-87e5-4026-87de-0265d1f48a49"
       }
-    }
+    },
+    "uuid": "fd5b572e-a0e2-48a6-99f8-ed098507e8d6"
   },
   "orange-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -940,7 +976,8 @@
         "value": "{orange-1100}",
         "uuid": "55baa188-9e75-4e31-b2db-729dd47ed1dd"
       }
-    }
+    },
+    "uuid": "bbcdb9c1-0c50-4f6d-8da1-37e166860f22"
   },
   "yellow-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -965,7 +1002,8 @@
         "value": "{yellow-1100}",
         "uuid": "08e44ba2-3627-4ce0-b8f5-eea6ce277517"
       }
-    }
+    },
+    "uuid": "b3abccc3-58c1-41b3-b9e2-c21e5610be67"
   },
   "chartreuse-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -990,7 +1028,8 @@
         "value": "{chartreuse-1100}",
         "uuid": "ebb64096-1155-4376-a13c-4a5db968253a"
       }
-    }
+    },
+    "uuid": "f78ade0c-eeb6-496f-b99d-657072f27485"
   },
   "celery-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1015,7 +1054,8 @@
         "value": "{celery-1100}",
         "uuid": "3e44abd8-ea12-4c0a-9007-4a6edaa3b962"
       }
-    }
+    },
+    "uuid": "2c159320-bf17-48b6-9d09-b2d037f937d1"
   },
   "green-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1040,7 +1080,8 @@
         "value": "{green-1100}",
         "uuid": "d9b7a966-e6c6-43a9-b2bd-6b72ff31aed7"
       }
-    }
+    },
+    "uuid": "2fc00105-857e-4eb5-a414-2cc6b4cd22ff"
   },
   "seafoam-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1065,7 +1106,8 @@
         "value": "{seafoam-1100}",
         "uuid": "4152095a-615b-4562-b183-78f765f6b3b0"
       }
-    }
+    },
+    "uuid": "29502bad-fdad-4a78-b60f-f515a62bac43"
   },
   "cyan-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1090,7 +1132,8 @@
         "value": "{cyan-1100}",
         "uuid": "64bd4cb9-d698-4fb0-8b56-c0c519245549"
       }
-    }
+    },
+    "uuid": "d228688c-fee3-460c-b2f0-6abce661db3d"
   },
   "blue-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1115,7 +1158,8 @@
         "value": "{blue-1100}",
         "uuid": "dd76a630-e1fd-4831-94db-8622af24f4da"
       }
-    }
+    },
+    "uuid": "7944588f-bff1-4669-8f8b-0ad3c028dce0"
   },
   "indigo-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1140,7 +1184,8 @@
         "value": "{indigo-1100}",
         "uuid": "71e2c0b9-4513-4679-9b97-ef1c345ec343"
       }
-    }
+    },
+    "uuid": "358aa988-9b99-4c33-8f5f-1198510ca5df"
   },
   "purple-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1165,7 +1210,8 @@
         "value": "{purple-1100}",
         "uuid": "cde24ea8-c181-42cb-9f71-0675628c5338"
       }
-    }
+    },
+    "uuid": "a65c1b35-c3f0-4ec9-8931-5168a526fe97"
   },
   "fuchsia-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1190,7 +1236,8 @@
         "value": "{fuchsia-1100}",
         "uuid": "5eb86ed6-384e-4e72-a615-8bab097bbec8"
       }
-    }
+    },
+    "uuid": "862d0909-d391-49b2-96f0-1c85f0048fc4"
   },
   "magenta-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1215,7 +1262,8 @@
         "value": "{magenta-1100}",
         "uuid": "299e780b-ddb9-444b-b416-2f33c9929be0"
       }
-    }
+    },
+    "uuid": "c92d3443-05b2-4290-a74e-c601ab758e9b"
   },
   "background-opacity-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
@@ -1365,7 +1413,8 @@
         "value": "{gray-500}",
         "uuid": "96d8bbe9-5fc6-4260-8cb3-5888836c4708"
       }
-    }
+    },
+    "uuid": "8c258b68-face-42d2-8115-4a20b1ff281f"
   },
   "accent-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1390,7 +1439,8 @@
         "value": "{accent-color-900}",
         "uuid": "a65c3f83-e46a-4d31-a6f0-de3b87479ea3"
       }
-    }
+    },
+    "uuid": "e9907cf2-5c99-4155-82a5-33e6657a5ba4"
   },
   "informative-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1415,7 +1465,8 @@
         "value": "{informative-color-900}",
         "uuid": "405f9ef3-b882-4c72-9f5e-47739a8ae9d6"
       }
-    }
+    },
+    "uuid": "a915f4f5-af40-46c6-a35a-0efb9d8aac53"
   },
   "negative-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1440,7 +1491,8 @@
         "value": "{negative-color-900}",
         "uuid": "ae218610-35ca-478d-8277-f032b1f85737"
       }
-    }
+    },
+    "uuid": "a1097979-35e2-43b0-99de-2cbe53ea00db"
   },
   "notice-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1465,7 +1517,8 @@
         "value": "{notice-color-900}",
         "uuid": "0cbb9365-59d0-4514-a352-b5379733c360"
       }
-    }
+    },
+    "uuid": "fe7cfa0e-c782-410f-a355-c1526222d9e4"
   },
   "positive-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1490,7 +1543,8 @@
         "value": "{positive-color-900}",
         "uuid": "cb447264-e862-4880-b9a3-f23028c836ac"
       }
-    }
+    },
+    "uuid": "0e1d30df-1779-4b28-ad93-64827e982d00"
   },
   "gray-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1515,7 +1569,8 @@
         "value": "{gray-500}",
         "uuid": "25d6638d-5597-4307-9a90-5ea276ce68c7"
       }
-    }
+    },
+    "uuid": "6854095c-ac3e-49b4-8753-5fc2eb7abb80"
   },
   "red-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1540,7 +1595,8 @@
         "value": "{red-900}",
         "uuid": "5fa19855-1c32-4fa7-9363-8edea0bad4e2"
       }
-    }
+    },
+    "uuid": "6c0a6428-ed2d-4f53-b986-fbc8c4d14e88"
   },
   "orange-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1565,7 +1621,8 @@
         "value": "{orange-900}",
         "uuid": "535ebae4-5308-4132-9ba7-2ead58c7af2d"
       }
-    }
+    },
+    "uuid": "dd5b5b66-e8a5-4c5b-9159-903d975345c2"
   },
   "yellow-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1590,7 +1647,8 @@
         "value": "{yellow-900}",
         "uuid": "24e58c48-8597-40f1-96e0-90ae08910665"
       }
-    }
+    },
+    "uuid": "411ea3a1-6d41-474b-81c5-8356eb2dbfe3"
   },
   "chartreuse-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1615,7 +1673,8 @@
         "value": "{chartreuse-900}",
         "uuid": "cea3da59-71a3-4ac6-b475-877ea2444839"
       }
-    }
+    },
+    "uuid": "30d087e8-d588-4bc6-96e3-59bf8e9565c1"
   },
   "celery-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1640,7 +1699,8 @@
         "value": "{celery-900}",
         "uuid": "88890424-a280-473b-a529-027e7ac828ac"
       }
-    }
+    },
+    "uuid": "a98a7116-e19c-4c8a-8c63-535f3fc3c2ee"
   },
   "green-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1665,7 +1725,8 @@
         "value": "{green-900}",
         "uuid": "b2ca6377-9a7b-467f-8352-bda31fd4abbf"
       }
-    }
+    },
+    "uuid": "790fa82a-ac72-4f0c-8238-3da2738dce44"
   },
   "seafoam-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1690,7 +1751,8 @@
         "value": "{seafoam-900}",
         "uuid": "7f641817-9a7d-4625-b534-3b7e38bb5eae"
       }
-    }
+    },
+    "uuid": "df95350c-00ab-47a3-a5b4-5685122cf31e"
   },
   "cyan-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1715,7 +1777,8 @@
         "value": "{cyan-900}",
         "uuid": "cf213ea9-796e-4263-8866-b16f66b95e97"
       }
-    }
+    },
+    "uuid": "8353f6f2-10ba-46c0-b348-e80148a0ba13"
   },
   "blue-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1740,7 +1803,8 @@
         "value": "{blue-900}",
         "uuid": "4d8f8afe-c348-459d-9006-bc60bd53df84"
       }
-    }
+    },
+    "uuid": "acc6aee5-ce5c-4b44-b8b5-10b118420ed8"
   },
   "indigo-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1765,7 +1829,8 @@
         "value": "{indigo-900}",
         "uuid": "7c047042-0227-420d-b78f-193d4534b218"
       }
-    }
+    },
+    "uuid": "89d267a2-a0ea-42e6-9cad-60eff42560e2"
   },
   "purple-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1790,7 +1855,8 @@
         "value": "{purple-900}",
         "uuid": "4b7780b2-d488-4446-88f8-cab0fd27bcd5"
       }
-    }
+    },
+    "uuid": "291aad5e-5dea-4318-98bd-16ed32ce4065"
   },
   "fuchsia-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1815,7 +1881,8 @@
         "value": "{fuchsia-900}",
         "uuid": "66316379-927a-4e47-a5dd-84eb0c82eba8"
       }
-    }
+    },
+    "uuid": "5df99248-f4ae-48cc-9f7f-5ea6da6f8942"
   },
   "magenta-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1840,7 +1907,8 @@
         "value": "{magenta-900}",
         "uuid": "4de213eb-5f57-45a2-bea7-5f1b402b81ff"
       }
-    }
+    },
+    "uuid": "787dba09-d1c2-4e52-985a-568a91234610"
   },
   "disabled-border-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -71,7 +71,8 @@
         "value": "{gray-200}",
         "uuid": "e7fe88a4-6ab3-4963-8f10-9908a5a83123"
       }
-    }
+    },
+    "uuid": "0b807f40-d63e-4482-8d53-18fadc9663d5"
   },
   "avatar-opacity-disabled": {
     "component": "avatar",

--- a/packages/tokens/src/color-palette.json
+++ b/packages/tokens/src/color-palette.json
@@ -143,7 +143,8 @@
         "uuid": "16ee1a81-e7d0-46ff-af81-5eca376ce203"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f668a787-a8e4-4d8f-861b-1ff7bd128793"
   },
   "gray-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -169,7 +170,8 @@
         "uuid": "4b6e738d-ac71-4d34-83eb-cd45e511b144"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "a8999689-c198-4d38-bbff-57fc217e7922"
   },
   "gray-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -195,7 +197,8 @@
         "uuid": "3605974e-8f93-4907-81b3-fb6ab55d03f8"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "55a0effe-1758-4b2f-908c-d36e460880b8"
   },
   "gray-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -221,7 +224,8 @@
         "uuid": "eaad36fe-2827-4404-8876-060de75c2b34"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "067d4f1e-c9cb-42f4-a108-cb5ded87f014"
   },
   "gray-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -247,7 +251,8 @@
         "uuid": "57d4b287-c9d9-4c56-894b-2df496d9a3b4"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "87708b3e-3407-4fb2-adc3-a8a1127a82b1"
   },
   "gray-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -273,7 +278,8 @@
         "uuid": "4634f126-2240-4de9-b244-ab2b833d70ef"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "a3d15bb5-3d17-4d5b-b7a6-f0b3b9d6bead"
   },
   "gray-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -299,7 +305,8 @@
         "uuid": "bc09529e-716c-4541-a75a-081ed9fdd860"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f413727c-d46a-4d66-a8a3-4b2dccd6efd8"
   },
   "gray-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -325,7 +332,8 @@
         "uuid": "3ab25385-aece-42c4-af86-01ea97ed2455"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "089feb70-0076-4745-ad5b-6edd6961caf6"
   },
   "gray-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -351,7 +359,8 @@
         "uuid": "b5201efc-0a69-4a87-8b9b-e869bcf03457"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "e8af5fd3-3237-483a-bca2-79c3e19c8cef"
   },
   "gray-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -377,7 +386,8 @@
         "uuid": "22e79b14-2a60-4721-8e9b-800fa9e7a128"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "5a77ca5d-b4b4-4ca9-bceb-b5fcd4a84edd"
   },
   "gray-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -403,7 +413,8 @@
         "uuid": "93fb6cac-b190-4a5a-951f-f5dc4c0d5978"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "78316eb8-0e0f-411a-8ff0-496e24d0c9b5"
   },
   "blue-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -429,7 +440,8 @@
         "uuid": "05ffb7a9-8bd9-46cd-bfb0-66217d52ceb1"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "64f3815b-e429-43f6-8a1c-4049f0f1722d"
   },
   "blue-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -455,7 +467,8 @@
         "uuid": "1f9bd0a5-d1ed-4d24-b8bf-273f5f22a5f4"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7e952162-5ef5-45d4-ae14-ebef50162185"
   },
   "blue-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -481,7 +494,8 @@
         "uuid": "94ed3997-5b56-41e8-9746-1d7515244c6e"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "3413a337-7b3c-4200-8423-42954df37461"
   },
   "blue-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -507,7 +521,8 @@
         "uuid": "23852b5e-2d80-4c89-946c-1c8c2fe37b39"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7c9368b4-a2ac-490f-95a4-c2d506a2f064"
   },
   "blue-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -533,7 +548,8 @@
         "uuid": "ca7117db-c105-446f-85e5-72f1191b9cfd"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "30ba29dc-5f28-47c7-b41f-2156c8943040"
   },
   "blue-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -559,7 +575,8 @@
         "uuid": "560dddaa-d4ae-4d84-8750-30eb72f9e33c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "fbd8fd2c-91bc-4531-86cc-cc71aba419d2"
   },
   "blue-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -585,7 +602,8 @@
         "uuid": "0a50f1d3-8ae9-4955-9b1e-3d18121a3302"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "003abb20-2cf8-4c48-ae35-bdff79ae6a02"
   },
   "blue-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -611,7 +629,8 @@
         "uuid": "84bc6532-7cb0-47ea-8951-b16bc2a7aab9"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "1473440e-654c-4475-81da-7e7e296ddebc"
   },
   "blue-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -637,7 +656,8 @@
         "uuid": "895407bb-8fda-4857-92a9-bf0cc06f2c3f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "e6b19f4c-0cc5-49cb-ac33-a7327b488d72"
   },
   "blue-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -663,7 +683,8 @@
         "uuid": "a50fef9e-d01f-490c-9baa-8c9672f1ac96"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "14fc0f42-79ab-4637-b6f6-921c857a3f13"
   },
   "blue-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -689,7 +710,8 @@
         "uuid": "85683533-e660-4037-ad0a-3d5e7714a757"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "d7935092-948a-4b48-be57-5ddf286cd351"
   },
   "blue-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -715,7 +737,8 @@
         "uuid": "ccde5f80-26bb-4de8-9982-0f7fd3a97e7d"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "3879055d-bec5-4f5c-a0e0-0380fbdb4951"
   },
   "blue-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -741,7 +764,8 @@
         "uuid": "4dbbc998-deeb-4268-9a6a-c49a57ff0bcc"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "e77e1e22-2ca0-4407-80ce-128a26d89f4d"
   },
   "blue-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -767,7 +791,8 @@
         "uuid": "0284c8ef-fd73-4c33-8f31-bc9a83a5a84f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "d79a2f66-b8e2-42ed-a886-8e3c44e9602f"
   },
   "red-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -793,7 +818,8 @@
         "uuid": "b9752d64-5683-4ddc-ae30-164c475a5d90"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "63b6ddb1-97f3-47eb-863b-c101d55591d6"
   },
   "red-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -819,7 +845,8 @@
         "uuid": "1d78cfc4-2c54-450e-9c5a-e3d3a40bcf32"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "31028ec2-bbf8-4236-a420-94c9912f8049"
   },
   "red-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -845,7 +872,8 @@
         "uuid": "c020ab70-b666-478b-aaf2-8e06c033f307"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "d70696c6-3143-423f-85c7-1b6514eac5af"
   },
   "red-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -871,7 +899,8 @@
         "uuid": "4ca331f0-9278-4ad7-9328-766e8a5f83e6"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "0a243ca7-4175-42f5-bc07-c9b19f938dda"
   },
   "red-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -897,7 +926,8 @@
         "uuid": "92784233-e6b0-4de0-8069-f3c037472dec"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "6a43e349-9df3-4f24-bebf-9c1c758839df"
   },
   "red-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -923,7 +953,8 @@
         "uuid": "3fe966a7-eac1-4e06-9652-271182ff332d"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "00fcc1d7-499a-460a-8c15-238e7a558dc2"
   },
   "red-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -949,7 +980,8 @@
         "uuid": "fd598b48-a775-4c72-92e5-55f357c33537"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "0e90c785-081e-4116-9c31-f045cddb4e36"
   },
   "red-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -975,7 +1007,8 @@
         "uuid": "abc67d6b-bd80-4e94-a91b-1f52216a5013"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "5fd887b0-a9c5-4e5a-a7fe-194ab7bc920b"
   },
   "red-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1001,7 +1034,8 @@
         "uuid": "f9fbdd87-77f6-4b99-b5f5-357604b57a48"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "5666d2b9-014c-43af-93f3-7f8583ad9818"
   },
   "red-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1027,7 +1061,8 @@
         "uuid": "d3c2852d-4d9f-4493-af1a-cba5269baf22"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "9f512db1-5b41-47d9-a4a9-1f3d0748b1f5"
   },
   "red-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1053,7 +1088,8 @@
         "uuid": "fb1cf925-d51e-4b6a-9cd1-ee711193a03a"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "d1af4f1a-2e93-4f79-bec7-1a406155b376"
   },
   "red-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1079,7 +1115,8 @@
         "uuid": "2caf3838-8be9-41d9-9cb9-fa2e6a2f8373"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c44f2505-e3fe-4bc7-87ba-7a2260510a1e"
   },
   "red-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1105,7 +1142,8 @@
         "uuid": "5e630b5e-ff35-4463-8db5-79519a54d64f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f89b3056-071e-4fc4-aec6-562c5d51d030"
   },
   "red-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1131,7 +1169,8 @@
         "uuid": "e70a8b5a-06ec-4771-9c16-9e74ae15c9bc"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b4e9ab89-23c0-41cf-aad5-cf2f2e47e5b7"
   },
   "orange-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1157,7 +1196,8 @@
         "uuid": "e4fff178-2055-4ec8-83e8-636a4ea8bb8c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "784a858d-b646-41d6-9a3f-95d849ec14eb"
   },
   "orange-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1183,7 +1223,8 @@
         "uuid": "47e53be7-b33b-48e3-abdf-fe48d59f8819"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "78415dd1-bbc2-4617-ad02-d56b1b76c73c"
   },
   "orange-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1209,7 +1250,8 @@
         "uuid": "c455298b-cc23-4504-b731-27be6433fbcd"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "22a43dda-14cb-41ba-8e53-cc4de56197eb"
   },
   "orange-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1235,7 +1277,8 @@
         "uuid": "2c08292c-e6cc-4dcb-9046-8a2af09d1e43"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "cfb5b180-7420-41db-896c-6873ba57edd0"
   },
   "orange-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1261,7 +1304,8 @@
         "uuid": "e6c70e40-f9e7-4975-af39-9458a8325c6f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f1eb78b7-92cd-4189-8e7c-9019318a04a7"
   },
   "orange-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1287,7 +1331,8 @@
         "uuid": "8a201cca-353e-4538-a6b5-efbc2fc86186"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "5afdf7f9-54d8-4737-b176-38244d1ce584"
   },
   "orange-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1313,7 +1358,8 @@
         "uuid": "58992b4e-69ab-4919-922a-dd9277cb770e"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c5651842-f13e-4498-9ce4-39ed84ef20ad"
   },
   "orange-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1339,7 +1385,8 @@
         "uuid": "8f42ee1b-59a5-4759-bef3-614835b348b2"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7a6946d1-8048-4853-a550-3fd972fdb72d"
   },
   "orange-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1365,7 +1412,8 @@
         "uuid": "69637678-cb68-46f1-9353-1c7d0f86e51e"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b742d374-2071-49df-96f1-49b299c21576"
   },
   "orange-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1391,7 +1439,8 @@
         "uuid": "bc744bfa-dd64-4660-b67c-105f07e66644"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c8fd1b70-72be-48b7-be8a-984436124058"
   },
   "orange-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1417,7 +1466,8 @@
         "uuid": "7aea0d8d-0fb0-47c1-ae6a-97510159359b"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b1213a46-91c5-43ff-a7a9-3fe96af0eb2e"
   },
   "orange-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1443,7 +1493,8 @@
         "uuid": "269da724-5ec7-4ceb-991d-1e83495cfaed"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "a0d46435-9054-4cd0-a5c8-8bf28187fb6d"
   },
   "orange-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1469,7 +1520,8 @@
         "uuid": "c1389efc-8e68-4e2d-94b1-17e193264be7"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "fef49d65-c699-4ff9-8265-b2041c08b2be"
   },
   "orange-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1495,7 +1547,8 @@
         "uuid": "0d6ed0c9-b185-4656-9985-04904a39f5e6"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f7a380d3-111d-442f-8e78-1d7cce68a4c2"
   },
   "yellow-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1521,7 +1574,8 @@
         "uuid": "be46f4fb-64d6-4e04-abd1-1f87c634d272"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c2803c8b-9e53-44cc-8f9a-dd7209191e2f"
   },
   "yellow-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1547,7 +1601,8 @@
         "uuid": "2e4d1e66-b660-4e99-8f01-ff9964aa19d8"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b80b77ef-cbb2-4797-8bda-b67ff8330266"
   },
   "yellow-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1573,7 +1628,8 @@
         "uuid": "6547eb52-a3a5-4004-8125-df92fed7a062"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "58a5ecc2-e5c3-4597-a366-cfece993fd1c"
   },
   "yellow-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1599,7 +1655,8 @@
         "uuid": "2c6515da-f97b-4961-93cf-5b6c668fc0fc"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "5211b5e1-262a-440b-900e-6417b7c071d3"
   },
   "yellow-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1625,7 +1682,8 @@
         "uuid": "8e450204-2aa5-4cb2-959b-8fc28f7f55bf"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "934f56c9-7533-4f7b-8843-6e0660e7fda2"
   },
   "yellow-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1651,7 +1709,8 @@
         "uuid": "dfdf38c7-1e23-44a8-8a62-a5f6c3a341bf"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "3fa9447b-781c-4964-b78e-9fc3f5d6c340"
   },
   "yellow-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1677,7 +1736,8 @@
         "uuid": "69c7c213-9a1c-4cd2-ac90-2142aa955e00"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "4a0220b0-9dd5-425d-b70d-3e4611052750"
   },
   "yellow-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1703,7 +1763,8 @@
         "uuid": "9ebe0ca0-5580-4083-899a-ba4a4638254d"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c2faf691-90e9-4f40-8998-0222a97275ca"
   },
   "yellow-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1729,7 +1790,8 @@
         "uuid": "a9e4cb0b-80af-417f-b8d5-b1a7aefa15e5"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f2f9cb7f-4199-4e1f-bc6e-b04010685168"
   },
   "yellow-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1755,7 +1817,8 @@
         "uuid": "7e7a2c49-bf61-4402-b85b-bf4df9ca8ff0"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "91d01994-882d-42f0-b0a0-6f604b6ea8a6"
   },
   "yellow-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1781,7 +1844,8 @@
         "uuid": "b54bc7bb-2347-4265-ba88-8af7fa420bdf"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "70cb2f4b-6bab-4456-a012-8367a77eb7e8"
   },
   "yellow-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1807,7 +1871,8 @@
         "uuid": "2e92e2de-12fa-45d3-be1d-5d875311bf1e"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "00a1fbb6-cd56-4ab8-bf94-b2745ddc39b9"
   },
   "yellow-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1833,7 +1898,8 @@
         "uuid": "21c27c6d-f054-48b4-abb8-5b0907e238e2"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "cf7a2ece-3af0-4aab-a962-f67f8cc5bab6"
   },
   "yellow-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1859,7 +1925,8 @@
         "uuid": "e0d95ec7-193d-40d1-9bd9-e68ff27c0275"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "80fcfe42-83d1-4e14-87d7-b38f8188ce5f"
   },
   "chartreuse-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1885,7 +1952,8 @@
         "uuid": "cc59e104-9997-4ed2-a29e-0af0b1a04b67"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b880507f-8faa-4f95-a45f-ff4c9cd8b7b1"
   },
   "chartreuse-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1911,7 +1979,8 @@
         "uuid": "838a5de8-2ec7-4814-8ba9-eaa4b0ad8e55"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "700ac2a7-ddab-4404-9b10-17f863397f25"
   },
   "chartreuse-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1937,7 +2006,8 @@
         "uuid": "bbb32db5-4835-4520-8bb1-ef2c8916c604"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b99d76b0-0200-438c-8d4a-96d8b2d19efd"
   },
   "chartreuse-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1963,7 +2033,8 @@
         "uuid": "eb857d3b-1956-4870-98cb-eaaffffaed85"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "d625422a-c661-4e4a-9c44-4be8d7380566"
   },
   "chartreuse-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -1989,7 +2060,8 @@
         "uuid": "7bffe928-4940-41b1-a9d4-3cbee27cb472"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "4e2b8114-d24d-44aa-8b71-e0217428027a"
   },
   "chartreuse-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2015,7 +2087,8 @@
         "uuid": "788108ff-5238-4a75-8936-092df93a3fd0"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f9fc8b5a-cc95-4fe2-b56a-6d98fad434e9"
   },
   "chartreuse-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2041,7 +2114,8 @@
         "uuid": "0386fb0b-3653-4015-a3a1-cbf047435f0f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "3d1ba440-370e-4594-b535-7a3e25c04fc4"
   },
   "chartreuse-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2067,7 +2141,8 @@
         "uuid": "c8046b7e-506c-47b7-8105-4d7e805f6b92"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "9c1c3ad4-9168-444e-9fc1-2cb688155b57"
   },
   "chartreuse-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2093,7 +2168,8 @@
         "uuid": "5f1f16c2-d562-4dd8-9b96-9d19b9a88093"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "746f8da2-ba48-4cf5-9ce1-4792b238b393"
   },
   "chartreuse-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2119,7 +2195,8 @@
         "uuid": "9a6983b0-a2ba-4633-a618-f3b4ac8f05c6"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "36b8ba5f-7621-4ef9-baa1-8407f337396a"
   },
   "chartreuse-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2145,7 +2222,8 @@
         "uuid": "8e44257e-ec8e-4459-863e-0bbbab65f6e0"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "3514e8ed-5240-45d1-a955-e14218b6995b"
   },
   "chartreuse-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2171,7 +2249,8 @@
         "uuid": "9af36936-6d05-4ba4-8beb-9b65bafb9277"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "9ce51df9-65eb-4418-bbf6-58b75c4d939a"
   },
   "chartreuse-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2197,7 +2276,8 @@
         "uuid": "acb36528-7ad1-497c-baf7-c53171ce4112"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "17a65a9b-e4dc-49e2-b3a5-6bbad0169848"
   },
   "chartreuse-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2223,7 +2303,8 @@
         "uuid": "485b7081-a921-42ee-b781-8a99bfeb84fa"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "d57b9f68-344b-42f5-b72b-22c32b075392"
   },
   "celery-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2249,7 +2330,8 @@
         "uuid": "a52ac86a-8627-483b-b747-6e8aa5fa7249"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "9948ef23-8968-4a49-a6ce-14ead429cc41"
   },
   "celery-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2275,7 +2357,8 @@
         "uuid": "a83229ca-de1f-4fdb-a72b-b8a3498a31bb"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "dc204ca4-8b04-4823-8da3-6c464af330b0"
   },
   "celery-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2301,7 +2384,8 @@
         "uuid": "5b271002-0fe2-4407-be21-7c09646a2303"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "4ef93614-2bac-41b8-ae98-95707697d2a1"
   },
   "celery-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2327,7 +2411,8 @@
         "uuid": "813b3e86-659b-48ee-b88d-122c13fa96e8"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "57d3d6ca-680a-41de-aee2-8e472ad9b820"
   },
   "celery-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2353,7 +2438,8 @@
         "uuid": "13e77335-22c0-470a-a5e5-da6363f622e0"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "9a3b61b3-60a2-403e-abcc-6a8568bec8c9"
   },
   "celery-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2379,7 +2465,8 @@
         "uuid": "a52a4fbf-dc30-4c09-b1d8-b25bcead712c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "317b7550-de28-4657-8bf0-5dfe79cb6b2a"
   },
   "celery-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2405,7 +2492,8 @@
         "uuid": "3e9a8018-a0bf-4562-867d-555c75c08d9f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "ea9cc920-eda5-4b73-b386-296333ebb1f5"
   },
   "celery-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2431,7 +2519,8 @@
         "uuid": "7a5096e0-6845-4ae5-bab4-d958c7e3dadb"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "5344d9fb-3ad2-4bd5-a115-f4754f87f6c1"
   },
   "celery-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2457,7 +2546,8 @@
         "uuid": "10c7c9b0-0d15-43ae-bf6f-84384783a9aa"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "2bbd48f8-0084-4e85-9bed-8f090f2d54da"
   },
   "celery-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2483,7 +2573,8 @@
         "uuid": "085d2bcb-85b1-4b55-842b-9559c457a1a0"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "876e1d10-865d-4dc6-a012-7e9ea9e0c1ca"
   },
   "celery-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2509,7 +2600,8 @@
         "uuid": "5c9ac732-7e1a-448c-b338-18d3b265d5d1"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "35d35ac3-a1f2-4bfb-89f5-b6806b8b762d"
   },
   "celery-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2535,7 +2627,8 @@
         "uuid": "865fc403-cab2-4e38-a181-e5e10523e04d"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "5fb14377-3a8e-49bc-bb73-781e11eed069"
   },
   "celery-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2561,7 +2654,8 @@
         "uuid": "cc88021a-ce1a-4f69-9208-d1b897a1d71b"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "33b27950-19cd-48d9-94d4-1cd6b9b4586e"
   },
   "celery-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2587,7 +2681,8 @@
         "uuid": "0fd51556-72b0-48ea-86f2-435bf64de316"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "352ea9ac-2b7f-43f1-b040-a1801568a017"
   },
   "green-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2613,7 +2708,8 @@
         "uuid": "f0702380-ed81-4f16-844c-b4c3b797161c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "276a4066-5ca6-4ade-b4f1-b3e58acf4377"
   },
   "green-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2639,7 +2735,8 @@
         "uuid": "b5d964d5-e68d-44c6-880f-2e23d2bae7ec"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "3b4b58b6-975d-4896-8828-f081825da89d"
   },
   "green-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2665,7 +2762,8 @@
         "uuid": "1aaecce9-f58c-44a5-9bb9-f62172ebcd21"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "d4de36bd-c29c-456b-becd-1234351f271f"
   },
   "green-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2691,7 +2789,8 @@
         "uuid": "8143aced-4012-4dc3-a132-2b5701e09a52"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "37ecd358-1206-4eef-a44e-e2b0dd01261c"
   },
   "green-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2717,7 +2816,8 @@
         "uuid": "9418d6a8-69a1-49a4-ac3d-d81c81a633be"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "dce88e4e-12c0-4218-a72d-e1fbd219dd81"
   },
   "green-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2743,7 +2843,8 @@
         "uuid": "57d2a064-3028-4225-82c4-e200e4abc6a3"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7578a7e1-8514-4b09-9573-255832c15926"
   },
   "green-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2769,7 +2870,8 @@
         "uuid": "fa823d25-6075-455b-a6f4-18de77a01f06"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b41aedde-9bf1-4e7b-b8aa-606b820d41a9"
   },
   "green-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2795,7 +2897,8 @@
         "uuid": "12755af6-ac1f-441a-80fb-07c3d61dc6c9"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "14f8e2f4-dad6-4b69-bdd4-d03e73003e04"
   },
   "green-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2821,7 +2924,8 @@
         "uuid": "81174c05-0b05-4030-a8b7-e2fc13533954"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "8ef877cc-6735-4b0f-949e-39fc9712f73f"
   },
   "green-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2847,7 +2951,8 @@
         "uuid": "a1c41ddd-5c54-4dce-bea3-51768998639c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7697d674-3253-4da7-984a-18b9aa2a35db"
   },
   "green-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2873,7 +2978,8 @@
         "uuid": "7f426d3d-5ff9-4ee2-b0e1-07282fe389df"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "0c851763-8bc6-4c70-a0b4-d5515a6cadf1"
   },
   "green-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2899,7 +3005,8 @@
         "uuid": "515298b6-f629-4c08-9e0f-18a5ba8fe20f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7d1049d6-3a01-4d8a-9405-d30c35fdc4f3"
   },
   "green-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2925,7 +3032,8 @@
         "uuid": "ce02582f-b327-4367-9f66-92dcc67fd072"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "9617a312-6be4-4777-a207-d9f74dbab583"
   },
   "green-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2951,7 +3059,8 @@
         "uuid": "51b8502d-e045-4b40-93e1-e2b49f6bf90c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b915ddcd-cb87-4c7b-99ae-d090051de24c"
   },
   "seafoam-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -2977,7 +3086,8 @@
         "uuid": "3c862893-b1e9-45df-99da-33906686d3c1"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "0166e259-f257-4c4f-a122-3aee06ad6dce"
   },
   "seafoam-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3003,7 +3113,8 @@
         "uuid": "4115d94a-b52e-4cc8-8067-cd9184030ffe"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c2caa7cc-f60c-4f7e-b71c-7e9f5d16b4f0"
   },
   "seafoam-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3029,7 +3140,8 @@
         "uuid": "56c4f393-086d-41d9-87d0-babaea86a2a4"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "79073fbb-6b19-413b-9a83-b268473aa401"
   },
   "seafoam-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3055,7 +3167,8 @@
         "uuid": "21467045-093e-461e-86ac-dc65b657bf50"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "fdb0e2ef-ca1a-4800-985b-ce5e083f4f2f"
   },
   "seafoam-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3081,7 +3194,8 @@
         "uuid": "50117040-ca43-4b90-832d-7e4c2d83c31c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "aa68b1a7-5b06-41ae-a372-01acc217469e"
   },
   "seafoam-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3107,7 +3221,8 @@
         "uuid": "0a450ad0-dd5e-414c-9b76-dac4ca20a1b8"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "a249c284-3775-49ad-9596-7b497f5efc3f"
   },
   "seafoam-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3133,7 +3248,8 @@
         "uuid": "c26d7e9d-fef9-4aa9-991b-bbac307e3c7a"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7725c5fd-db09-4b41-aba2-0cce5ea894b7"
   },
   "seafoam-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3159,7 +3275,8 @@
         "uuid": "7a88f0bf-59cb-4af3-9542-f7648fecd50e"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f07bd231-b065-4ec2-9021-593adf11b0b6"
   },
   "seafoam-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3185,7 +3302,8 @@
         "uuid": "8e444b02-f977-4948-b862-63275642ad58"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "4cc18837-1143-45f8-b5f8-bbe5c2255dae"
   },
   "seafoam-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3211,7 +3329,8 @@
         "uuid": "72873817-3cf5-4a14-aa93-1f86b4c6f7f2"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "59e0a6f6-b508-4692-9b66-f95188a7e4cf"
   },
   "seafoam-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3237,7 +3356,8 @@
         "uuid": "fb3f4cf4-e032-4cc1-94b1-d122f0d695ac"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "effca489-bb2f-442e-b129-c8aea79f732d"
   },
   "seafoam-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3263,7 +3383,8 @@
         "uuid": "8a7fb1d7-90ca-41d1-a04c-84bd1d70d9ec"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "0ab0f9f2-fc1c-441a-bf59-905afdfc2c6c"
   },
   "seafoam-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3289,7 +3410,8 @@
         "uuid": "3e88a833-9ef2-4f37-86a1-041e76850e1e"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "d1d66e58-dca2-459e-9b36-5b065baab4a1"
   },
   "seafoam-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3315,7 +3437,8 @@
         "uuid": "badc0d78-4232-44f0-8911-e9e2f0eab94f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7e74f5c0-aac3-4b7b-9d0d-aa32318fbc9b"
   },
   "cyan-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3341,7 +3464,8 @@
         "uuid": "28fe7c7b-b43c-4650-9155-5b0f5ec27a09"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "769520e3-f099-4127-b0a7-053a5cd7f064"
   },
   "cyan-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3367,7 +3491,8 @@
         "uuid": "b6b314ea-f9ba-4f49-a115-f4177ecb7bbc"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c60f9f06-af09-417d-bb93-8e468cfd0f28"
   },
   "cyan-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3393,7 +3518,8 @@
         "uuid": "f7d51b4b-6c95-4271-a51e-4ad5a1660591"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "2d6619da-85d7-40ff-92cf-0c8e2eb360a5"
   },
   "cyan-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3419,7 +3545,8 @@
         "uuid": "6c2a20c7-e453-4401-a0b4-8e0d1d7edd7e"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "2cd007c2-65d6-4738-bb25-121e696fd0e2"
   },
   "cyan-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3445,7 +3572,8 @@
         "uuid": "39f96e8f-c9c8-4158-8da9-6825cd084fc3"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "77084572-b45e-4442-9020-7eee983adc27"
   },
   "cyan-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3471,7 +3599,8 @@
         "uuid": "6f67dfce-62d0-4147-aac6-33873a325cd3"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "219d3909-cfb6-41c3-8289-4593bd7e2701"
   },
   "cyan-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3497,7 +3626,8 @@
         "uuid": "08173787-f50d-48a7-badc-141a9e7b7981"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "78f198c9-5ad5-449b-9d6e-0929be1adf9d"
   },
   "cyan-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3523,7 +3653,8 @@
         "uuid": "a006424a-ad2b-4091-a38d-b4af80ddc03e"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "70fa195e-aef5-403f-9805-7540a657c7b7"
   },
   "cyan-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3549,7 +3680,8 @@
         "uuid": "03de1fef-9ae1-457d-917b-6f22fb545d00"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "14e16755-6644-4d61-a83c-610454602193"
   },
   "cyan-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3575,7 +3707,8 @@
         "uuid": "8dd5e110-aa2f-47b2-aa21-30bc4241db86"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "a7c38642-509e-4392-992d-b65445f9d096"
   },
   "cyan-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3601,7 +3734,8 @@
         "uuid": "4698ba84-dab0-4b6b-a2b1-e289261aa7b4"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "429c47d3-91bd-4f17-89c3-58fb0ee61fa4"
   },
   "cyan-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3627,7 +3761,8 @@
         "uuid": "8e12e7fe-546a-4e8c-92eb-56673446b1bb"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "cf78f2f1-5a0f-4181-9aac-8a0b05073707"
   },
   "cyan-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3653,7 +3788,8 @@
         "uuid": "958d5c96-6b57-47c2-a9a5-f589c054aa13"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "ee6ab17e-86d3-4300-b759-7396d7ca362b"
   },
   "cyan-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3679,7 +3815,8 @@
         "uuid": "8a2d9c8d-a95a-48ac-b6eb-0ca1d5e69bd7"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b78fe68e-fb93-4325-84a6-f54c8baa59ef"
   },
   "indigo-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3705,7 +3842,8 @@
         "uuid": "37af1036-6ba7-4eac-b1a5-9442ff55036f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f0c3fe87-ae87-4be0-98f7-6dc7ee8733be"
   },
   "indigo-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3731,7 +3869,8 @@
         "uuid": "401d532f-8374-4e5a-99c5-51c4ec9bc344"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "3cb5777a-5c5b-424d-ba5f-5bf7895f724e"
   },
   "indigo-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3757,7 +3896,8 @@
         "uuid": "fb607a6f-2d62-4163-a6a3-068b80a084da"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "48cf3d1e-40f4-4882-8c4f-f0d158b24a56"
   },
   "indigo-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3783,7 +3923,8 @@
         "uuid": "5cd6358b-bdc0-488e-a5fe-089a769b6bfb"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "1d68b577-0fba-47a1-9ec6-6bb03d1c7f72"
   },
   "indigo-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3809,7 +3950,8 @@
         "uuid": "a9e657da-8f33-425a-b2ab-dca9d1337bf3"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "030f7a1c-b3a3-48b8-8e36-c91ae0c2114a"
   },
   "indigo-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3835,7 +3977,8 @@
         "uuid": "233a1b84-3ab6-4899-9b41-d9177356c175"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7a3cfd26-9e21-4431-b012-389f3dc577ad"
   },
   "indigo-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3861,7 +4004,8 @@
         "uuid": "feeeaa05-5c75-4a06-b5be-ed8bf3ecd773"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "a507c184-5736-4c38-a067-d7e6f629ebfd"
   },
   "indigo-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3887,7 +4031,8 @@
         "uuid": "63e9a41c-ee85-43c1-b550-3ca8ce7c0986"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "9e4b6c3f-4288-4580-b398-56f39682c45b"
   },
   "indigo-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3913,7 +4058,8 @@
         "uuid": "39f6823f-ca35-413c-ad64-31529710cf3c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "15ccd190-830c-4b93-af17-488ae1b7708e"
   },
   "indigo-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3939,7 +4085,8 @@
         "uuid": "ef5ddbb5-3e37-4806-b863-9369294dc07a"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "70e1eb55-2dda-4a84-8cd0-47f1b68ae0ab"
   },
   "indigo-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3965,7 +4112,8 @@
         "uuid": "f4c7c283-b412-4acc-b2f5-0339f946ff3d"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f7e71981-4756-42c8-ba41-5a2af2db93f3"
   },
   "indigo-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -3991,7 +4139,8 @@
         "uuid": "91d7c77f-6cb0-4f1d-92ea-03965a296cc6"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f17fd1a0-4fe0-4e4e-9331-9880c32cb8dc"
   },
   "indigo-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4017,7 +4166,8 @@
         "uuid": "a274d960-197e-4045-99d3-9919cfa90e6e"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "783ddb63-4810-40ef-bf1e-ca7b62cef6cc"
   },
   "indigo-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4043,7 +4193,8 @@
         "uuid": "46fa9ff8-5758-41c3-b0aa-fefd075eb739"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "72913637-2902-458d-a279-4f38ac1d2926"
   },
   "purple-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4069,7 +4220,8 @@
         "uuid": "8898f93b-9e3f-4143-bb78-fd0afd4c4ee0"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "7d2d2fd5-1e6a-4299-a86a-0a15cf985453"
   },
   "purple-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4095,7 +4247,8 @@
         "uuid": "0980d65e-bf37-40c7-a59c-5a0c80795211"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "cf5d51e1-b890-4f48-a05a-5c1aac83cd7f"
   },
   "purple-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4121,7 +4274,8 @@
         "uuid": "2f450b24-782a-428f-80ff-9d762e22e44c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "2283b357-6479-45c0-a26c-3e80c19e8053"
   },
   "purple-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4147,7 +4301,8 @@
         "uuid": "7faf15d0-6890-4cde-919e-1b720d5bfc0a"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "d55a6634-3973-4451-96de-7cdf9ec74d8b"
   },
   "purple-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4173,7 +4328,8 @@
         "uuid": "2473ee91-ecb3-414d-ac05-8b040aee3283"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "8d9cfcad-2381-4fe8-9bc6-8efd30297410"
   },
   "purple-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4199,7 +4355,8 @@
         "uuid": "78f628a8-2d9f-4532-8502-bf389ec8ae7d"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "8a59e341-bb35-4a54-9b35-364f498364c7"
   },
   "purple-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4225,7 +4382,8 @@
         "uuid": "8cdcca2d-71d7-4a08-b7a0-072e954980fe"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "bcbb83ab-93d4-4112-91e5-f3ce82120016"
   },
   "purple-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4251,7 +4409,8 @@
         "uuid": "32ee4548-9a32-476b-a245-f0af6c701fdb"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "dc780ef5-84b9-4fb9-bb34-532d2ce49bdf"
   },
   "purple-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4277,7 +4436,8 @@
         "uuid": "1f898f83-cd72-4bf1-bd66-ee1486a0f70d"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "4dc5cd47-bedf-4597-8f07-d0baf59a7484"
   },
   "purple-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4303,7 +4463,8 @@
         "uuid": "2287f92f-6851-4f5f-b48c-3a43067a7a08"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "e36883ef-a17f-4fdb-aa27-bb37a13533f6"
   },
   "purple-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4329,7 +4490,8 @@
         "uuid": "ed68aade-7d0a-4029-bf17-9a3b88f08ceb"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "0f787b0a-7d58-45f0-991b-ba135ccd6d28"
   },
   "purple-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4355,7 +4517,8 @@
         "uuid": "aa502b60-e84f-4a35-910f-de28016d44fc"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f204d5e8-4a3e-4c87-b874-0ac57b486424"
   },
   "purple-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4381,7 +4544,8 @@
         "uuid": "eeb7a71b-1a59-4629-a1fd-4fe9bae6d3db"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "a864777a-b7c9-4d2f-82d4-5cc6782efc6b"
   },
   "purple-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4407,7 +4571,8 @@
         "uuid": "10c0a8e7-8496-4421-bfa0-cc41af6271d7"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "df523779-ea77-4ef9-bf11-573d9ea021c6"
   },
   "fuchsia-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4433,7 +4598,8 @@
         "uuid": "c826bbb3-badb-48a1-becf-86f5f395eef7"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "8eb8a9eb-5e08-4c2a-937f-0f17ece1da8d"
   },
   "fuchsia-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4459,7 +4625,8 @@
         "uuid": "eed8370d-a367-4333-ba69-56843a7657ba"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c4d01ae4-8b14-45ed-ab72-5211cf18a07a"
   },
   "fuchsia-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4485,7 +4652,8 @@
         "uuid": "7b52a8c6-67b3-4d8c-b506-aa5eeababdfb"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "1e502d0b-6d88-4f73-a493-2911621cf2c8"
   },
   "fuchsia-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4511,7 +4679,8 @@
         "uuid": "670788fe-2614-4673-bda2-681622680109"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "6ef05285-e6da-4c5e-9ca4-0c9cbccb0090"
   },
   "fuchsia-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4537,7 +4706,8 @@
         "uuid": "906889fa-ad69-4129-978c-23ea12d2b362"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "92ca51c5-b4a9-4ac4-a384-4158a425041a"
   },
   "fuchsia-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4563,7 +4733,8 @@
         "uuid": "0b09ae9a-7aa8-4b63-b6c4-4317b03dc3ff"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "13cac94c-eebe-4504-b034-fc79d4d6ce68"
   },
   "fuchsia-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4589,7 +4760,8 @@
         "uuid": "02b7bf12-ff14-4829-aa9b-52c3033b0652"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "fbc24eea-0ccb-4fa3-bb78-09d5b8988c67"
   },
   "fuchsia-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4615,7 +4787,8 @@
         "uuid": "a6344998-b1e8-4651-a4c9-b1b2aa22d48b"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "30a9972a-13f9-45eb-811a-e8819e16733f"
   },
   "fuchsia-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4641,7 +4814,8 @@
         "uuid": "2a29020c-1524-4b9b-a249-25b9927d4a54"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "e6d9c311-509d-4fe4-b225-afb752044df6"
   },
   "fuchsia-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4667,7 +4841,8 @@
         "uuid": "7606b799-458c-466e-96c6-a0a7e949a83c"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c39fca6a-7e8e-4c39-a5fd-38b1c6dad0bd"
   },
   "fuchsia-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4693,7 +4868,8 @@
         "uuid": "aa82e21e-e5a2-4bcd-a63d-a2d76c467ac7"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "6db3f51e-bacc-4ab8-9be5-4858f74884c7"
   },
   "fuchsia-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4719,7 +4895,8 @@
         "uuid": "bdb3a49e-331e-44b9-96e2-4f1dccdae565"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "e9b1dc85-6d6e-4b1f-8d9b-2e35198a6b8f"
   },
   "fuchsia-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4745,7 +4922,8 @@
         "uuid": "c53a7f46-12aa-48c9-afdf-20e7a26bbb09"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "e6bed7fe-2b70-43d1-bd81-3d06bf45256c"
   },
   "fuchsia-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4771,7 +4949,8 @@
         "uuid": "ee6b1d77-41ce-4c87-9d95-098f5fc66da9"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "200a6384-7f09-4b2f-b5ac-a106c8cd6fd1"
   },
   "magenta-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4797,7 +4976,8 @@
         "uuid": "3f70bddc-f8e3-41a1-a68e-9500ac9a2474"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "ce26417e-9bb8-411e-a026-464293b06add"
   },
   "magenta-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4823,7 +5003,8 @@
         "uuid": "074993b8-2652-448c-a6ca-b18a39176ed9"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "874c0257-997e-47fc-8034-aab4e96f97fe"
   },
   "magenta-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4849,7 +5030,8 @@
         "uuid": "04b09fbb-08cb-4fe3-a287-d7de2bf39312"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "f694bd14-d565-4ec2-baff-304500e438b3"
   },
   "magenta-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4875,7 +5057,8 @@
         "uuid": "41d578d1-c853-4360-95e9-b94ad61e7786"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "43d8a547-4a3b-4bf4-afa6-a22e99811644"
   },
   "magenta-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4901,7 +5084,8 @@
         "uuid": "0734c859-3e4c-4974-98e2-700c49c69bcd"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "9d63598b-15dc-42d8-81f0-84bb906bfbdb"
   },
   "magenta-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4927,7 +5111,8 @@
         "uuid": "e70126f5-e8d6-47e2-9737-0dbb17655b1f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "5bddfcd1-4c98-45b7-a2b3-ad63bb55eaec"
   },
   "magenta-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4953,7 +5138,8 @@
         "uuid": "e5ffefaa-72d6-444d-8f9f-3fb08a9f2480"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "b5538c34-e3ef-4f42-a8e7-a0382bf74d16"
   },
   "magenta-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -4979,7 +5165,8 @@
         "uuid": "6dca10b8-2ed2-463c-82f5-fad66a833675"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "2da326e7-e8c4-4a4c-98bf-f8bd903c434a"
   },
   "magenta-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -5005,7 +5192,8 @@
         "uuid": "991792f1-03ed-494b-ada7-1beb965e39c9"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "2b5073f4-450b-4c86-8c12-a52b75a4ff00"
   },
   "magenta-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -5031,7 +5219,8 @@
         "uuid": "8a8e447b-6b31-4758-b59e-51acad7c9210"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "c93e3507-c6b1-4560-a7cb-5d5113b5392c"
   },
   "magenta-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -5057,7 +5246,8 @@
         "uuid": "9784741b-612e-4986-952b-a102c04e2afd"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "1f891345-4822-4977-8dee-b2161f1289ef"
   },
   "magenta-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -5083,7 +5273,8 @@
         "uuid": "3c632a35-bf86-4182-9475-84854a20f15a"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "cbde36d9-8429-4904-9148-a3ede646d148"
   },
   "magenta-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -5109,7 +5300,8 @@
         "uuid": "030c6431-3ea5-429b-a492-1a01dd396d44"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "2a7b30ec-db12-4ba6-8316-c134705a5867"
   },
   "magenta-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
@@ -5135,6 +5327,7 @@
         "uuid": "b6dd1b22-5f8f-46d8-924e-4ce02ad5a99f"
       }
     },
-    "private": true
+    "private": true,
+    "uuid": "336a0cef-c962-4847-9eba-2d6e9571c790"
   }
 }

--- a/packages/tokens/src/icons.json
+++ b/packages/tokens/src/icons.json
@@ -35,7 +35,8 @@
         "value": "{blue-900}",
         "uuid": "20880dfd-57dc-486d-b0dd-c44002f340e3"
       }
-    }
+    },
+    "uuid": "a52ced5f-2e8d-4ab9-bddb-fbbf32860256"
   },
   "icon-color-green-primary-default": {
     "component": "icon",
@@ -61,7 +62,8 @@
         "value": "{green-900}",
         "uuid": "d6852796-baaa-4f95-9ce7-cc2fd5a829f1"
       }
-    }
+    },
+    "uuid": "d403d8a1-3ac2-4f6d-9434-6aebe4f23991"
   },
   "icon-color-red-primary-default": {
     "component": "icon",
@@ -87,7 +89,8 @@
         "value": "{red-900}",
         "uuid": "d524a471-2dce-4497-a650-30c2d6641eec"
       }
-    }
+    },
+    "uuid": "5b809bc6-8ac3-4ec1-a7bb-b88863b1905b"
   },
   "icon-color-yellow-primary-default": {
     "component": "icon",
@@ -113,7 +116,8 @@
         "value": "{yellow-400}",
         "uuid": "4a1eeded-e467-46be-a787-78555b2fe353"
       }
-    }
+    },
+    "uuid": "52b34bcf-a2dc-41a4-855c-0a786a234d5d"
   },
   "workflow-icon-size-50": {
     "component": "icon",
@@ -129,7 +133,8 @@
         "value": "18px",
         "uuid": "4c4cb541-7d42-4bb4-9c86-7197c4600896"
       }
-    }
+    },
+    "uuid": "1e2f7368-9813-4cda-aa32-a2d0bc03f41c"
   },
   "workflow-icon-size-75": {
     "component": "icon",
@@ -145,7 +150,8 @@
         "value": "20px",
         "uuid": "b720c214-babe-426d-9629-9ec60d5e8622"
       }
-    }
+    },
+    "uuid": "b2effa58-727a-4a52-8680-296b0f83f0aa"
   },
   "workflow-icon-size-100": {
     "component": "icon",
@@ -161,7 +167,8 @@
         "value": "22px",
         "uuid": "9e882a20-b8e1-4e9b-89f9-26f21db3cd78"
       }
-    }
+    },
+    "uuid": "1ac9ea9c-59ab-41f7-966e-f1b5c290e4a1"
   },
   "workflow-icon-size-200": {
     "component": "icon",
@@ -177,7 +184,8 @@
         "value": "24px",
         "uuid": "9948e083-8c75-48f7-8e58-32c75ec76116"
       }
-    }
+    },
+    "uuid": "e8863648-66c4-4ffa-8aa2-53f91ca331c7"
   },
   "workflow-icon-size-300": {
     "component": "icon",
@@ -193,7 +201,8 @@
         "value": "28px",
         "uuid": "df0dc6c3-59fc-4ee0-87a9-c3d49a07cf9c"
       }
-    }
+    },
+    "uuid": "7d699674-dab8-4f5b-a022-51dc67b7fc45"
   },
   "arrow-icon-size-75": {
     "component": "icon",
@@ -209,7 +218,8 @@
         "value": "12px",
         "uuid": "6ff35aff-8a9f-466c-bdd3-dda460ccaee5"
       }
-    }
+    },
+    "uuid": "ec025bb5-a58e-486b-98f5-c8c2fde55a0a"
   },
   "arrow-icon-size-100": {
     "component": "icon",
@@ -225,7 +235,8 @@
         "value": "14px",
         "uuid": "e9b3eb08-2004-4ad3-bb13-a00a6cb536aa"
       }
-    }
+    },
+    "uuid": "2c9e49ab-e572-4ed5-90d0-5213dff5fec6"
   },
   "arrow-icon-size-200": {
     "component": "icon",
@@ -241,7 +252,8 @@
         "value": "16px",
         "uuid": "c7df43e2-7354-4f53-b453-dc9bf9060e64"
       }
-    }
+    },
+    "uuid": "a18e9723-eb3b-470c-82d8-b3544bf587d7"
   },
   "arrow-icon-size-300": {
     "component": "icon",
@@ -257,7 +269,8 @@
         "value": "16px",
         "uuid": "f6116604-efbe-4c6f-b047-29247d632174"
       }
-    }
+    },
+    "uuid": "fd4b3d4e-a9e9-4448-881a-9bd7fcda991a"
   },
   "arrow-icon-size-400": {
     "component": "icon",
@@ -273,7 +286,8 @@
         "value": "18px",
         "uuid": "35f055a9-8a33-42b2-a316-7e2ef0a4b99d"
       }
-    }
+    },
+    "uuid": "9101e9df-cc20-44b1-b183-8d9ac7146f0d"
   },
   "arrow-icon-size-500": {
     "component": "icon",
@@ -289,7 +303,8 @@
         "value": "22px",
         "uuid": "dcf16e1a-49ea-4888-85b7-012462a60f40"
       }
-    }
+    },
+    "uuid": "b86d209f-21d1-4c61-9c89-010b676f8389"
   },
   "arrow-icon-size-600": {
     "component": "icon",
@@ -305,7 +320,8 @@
         "value": "24px",
         "uuid": "2f5f49e5-9aba-4ea0-a8d9-0f0e4c086b89"
       }
-    }
+    },
+    "uuid": "ac841dee-47e8-47f3-b2b2-add8b4333eba"
   },
   "asterisk-icon-size-75": {
     "component": "icon",
@@ -327,7 +343,8 @@
         "value": "10px",
         "uuid": "f6f11ca3-b78b-4207-868f-f834c19e8d3d"
       }
-    }
+    },
+    "uuid": "bcd47b11-a4b1-4b1b-a082-36c3554d0eef"
   },
   "asterisk-icon-size-200": {
     "component": "icon",
@@ -343,7 +360,8 @@
         "value": "12px",
         "uuid": "3f1b200b-d341-41e4-ae7b-c981ccb492f7"
       }
-    }
+    },
+    "uuid": "8e6912ef-2ee2-4048-85e7-c758f2d0cced"
   },
   "asterisk-icon-size-300": {
     "component": "icon",
@@ -359,7 +377,8 @@
         "value": "12px",
         "uuid": "a1cdad1f-6537-4c35-a87b-45d8e161ee46"
       }
-    }
+    },
+    "uuid": "65b34b9b-ddfa-4cbd-bfb4-56bcc60eca86"
   },
   "checkmark-icon-size-50": {
     "component": "icon",
@@ -375,7 +394,8 @@
         "value": "12px",
         "uuid": "ee52f114-1ab6-430b-bd54-62a82bf3600e"
       }
-    }
+    },
+    "uuid": "968c7096-a064-444f-a449-6388bef7b74b"
   },
   "checkmark-icon-size-75": {
     "component": "icon",
@@ -391,7 +411,8 @@
         "value": "12px",
         "uuid": "99224b4e-751a-49ec-8db4-41c8cc4c7bf5"
       }
-    }
+    },
+    "uuid": "15df2603-7450-461b-b042-c952a90f65e5"
   },
   "checkmark-icon-size-100": {
     "component": "icon",
@@ -407,7 +428,8 @@
         "value": "14px",
         "uuid": "23247915-3cc0-4fdf-b21a-85b97019a219"
       }
-    }
+    },
+    "uuid": "9203c333-afaf-484d-8f4a-d26e6d88e70a"
   },
   "checkmark-icon-size-200": {
     "component": "icon",
@@ -423,7 +445,8 @@
         "value": "14px",
         "uuid": "d4e3f5ff-91d6-499e-b79e-b1d85c0c597b"
       }
-    }
+    },
+    "uuid": "c81d8bc2-63b7-4416-9451-0d6030d10c56"
   },
   "checkmark-icon-size-300": {
     "component": "icon",
@@ -439,7 +462,8 @@
         "value": "16px",
         "uuid": "d9b251b2-aa8a-46dc-9a2a-0eb46afea241"
       }
-    }
+    },
+    "uuid": "e05fceb5-a187-465f-951b-c39d047603ca"
   },
   "checkmark-icon-size-400": {
     "component": "icon",
@@ -455,7 +479,8 @@
         "value": "18px",
         "uuid": "c044459e-12a3-4cdd-9f22-db1d14f34164"
       }
-    }
+    },
+    "uuid": "8e9669a7-42aa-4f03-a7fd-39fb0a0cdc74"
   },
   "checkmark-icon-size-500": {
     "component": "icon",
@@ -471,7 +496,8 @@
         "value": "20px",
         "uuid": "29f107aa-b8a8-4a09-bf55-9c903c1005ed"
       }
-    }
+    },
+    "uuid": "43df0124-93a2-4014-934f-2919b4849ec1"
   },
   "checkmark-icon-size-600": {
     "component": "icon",
@@ -487,7 +513,8 @@
         "value": "24px",
         "uuid": "b52f4e53-06c2-4746-8063-e2bd99361174"
       }
-    }
+    },
+    "uuid": "c4a6e802-723f-4198-80a3-0c70ae5c8a8c"
   },
   "chevron-icon-size-50": {
     "component": "icon",
@@ -503,7 +530,8 @@
         "value": "8px",
         "uuid": "6d8ce7eb-a2a2-496c-9ce7-847f4da5fc0c"
       }
-    }
+    },
+    "uuid": "40f343b7-daf4-499e-8183-0140eb5bcedd"
   },
   "chevron-icon-size-75": {
     "component": "icon",
@@ -519,7 +547,8 @@
         "value": "12px",
         "uuid": "74dbb8c0-2e65-413d-8b52-7215993b5696"
       }
-    }
+    },
+    "uuid": "c53d444c-71c2-4b59-81ee-b2e0af7911c6"
   },
   "chevron-icon-size-100": {
     "component": "icon",
@@ -535,7 +564,8 @@
         "value": "14px",
         "uuid": "c4d6bea8-61b0-45a4-81e0-1e5dd7429463"
       }
-    }
+    },
+    "uuid": "f3f0a237-be83-48c7-9048-6e63b164d456"
   },
   "chevron-icon-size-200": {
     "component": "icon",
@@ -551,7 +581,8 @@
         "value": "14px",
         "uuid": "08bbd8dd-bb02-43b9-8e25-7709aee5ff52"
       }
-    }
+    },
+    "uuid": "34006e8c-3325-43cd-b1d6-b338b6237956"
   },
   "chevron-icon-size-300": {
     "component": "icon",
@@ -567,7 +598,8 @@
         "value": "16px",
         "uuid": "e6fdcac2-9916-45e2-a479-e87d17ece1f9"
       }
-    }
+    },
+    "uuid": "e00b08d9-9137-4f4b-9387-51ec17b391d3"
   },
   "chevron-icon-size-400": {
     "component": "icon",
@@ -583,7 +615,8 @@
         "value": "18px",
         "uuid": "ee913eaa-bdaf-44c0-a139-17c5d94b1d4a"
       }
-    }
+    },
+    "uuid": "c8b087cf-ad51-4d46-9dfe-ac2617942edd"
   },
   "chevron-icon-size-500": {
     "component": "icon",
@@ -599,7 +632,8 @@
         "value": "20px",
         "uuid": "95400787-7abb-4cad-830b-8a4042831860"
       }
-    }
+    },
+    "uuid": "c39f4b1b-967f-463f-880a-f6ba523fbcf3"
   },
   "chevron-icon-size-600": {
     "component": "icon",
@@ -615,7 +649,8 @@
         "value": "24px",
         "uuid": "350b77ab-6440-49c1-9b1c-a31c5c4f2f5f"
       }
-    }
+    },
+    "uuid": "5221f3ca-cc93-4b2e-ab74-35da255866ca"
   },
   "corner-triangle-icon-size-75": {
     "component": "icon",
@@ -631,7 +666,8 @@
         "value": "6px",
         "uuid": "434b019c-efde-437a-967b-b841ec95e621"
       }
-    }
+    },
+    "uuid": "bed0e624-9aa1-403a-b1cc-74c6afb84647"
   },
   "corner-triangle-icon-size-100": {
     "component": "icon",
@@ -647,7 +683,8 @@
         "value": "7px",
         "uuid": "1352ad8f-a8ec-459d-8ae3-71c27038a29d"
       }
-    }
+    },
+    "uuid": "1c3e00ad-6915-470a-b34a-853c88844cbc"
   },
   "corner-triangle-icon-size-200": {
     "component": "icon",
@@ -663,7 +700,8 @@
         "value": "8px",
         "uuid": "2be65bca-0f16-4754-bc8a-4a491ba87b90"
       }
-    }
+    },
+    "uuid": "0ff629b0-fcb9-4aee-9cde-68df68825de9"
   },
   "corner-triangle-icon-size-300": {
     "component": "icon",
@@ -679,7 +717,8 @@
         "value": "8px",
         "uuid": "d396d74a-425d-4f06-837f-349f81ebf486"
       }
-    }
+    },
+    "uuid": "09f106e8-600f-4868-984a-61e3b65a735e"
   },
   "cross-icon-size-75": {
     "component": "icon",
@@ -695,7 +734,8 @@
         "value": "10px",
         "uuid": "622d259d-b52b-409a-bf58-04705d8423f9"
       }
-    }
+    },
+    "uuid": "e426da6e-cf18-4f5d-8ba1-218f3ec51973"
   },
   "cross-icon-size-100": {
     "component": "icon",
@@ -711,7 +751,8 @@
         "value": "10px",
         "uuid": "11f924ca-5542-4864-b153-77363a32d690"
       }
-    }
+    },
+    "uuid": "4d4a0ad7-d306-44fd-9492-0b30e62eca8c"
   },
   "cross-icon-size-200": {
     "component": "icon",
@@ -727,7 +768,8 @@
         "value": "12px",
         "uuid": "11f65b04-c50d-45bb-86bd-34520aa7db61"
       }
-    }
+    },
+    "uuid": "b5324225-dbca-4fb7-a2d7-48b200c99f58"
   },
   "cross-icon-size-300": {
     "component": "icon",
@@ -743,7 +785,8 @@
         "value": "14px",
         "uuid": "37867ac1-4101-4553-98e1-c8a94fdd2d66"
       }
-    }
+    },
+    "uuid": "40c2d521-24a5-401a-8166-eb6f6635f46d"
   },
   "cross-icon-size-400": {
     "component": "icon",
@@ -759,7 +802,8 @@
         "value": "16px",
         "uuid": "2fed48b7-dd3d-4c3c-9d5c-3046934f5cfd"
       }
-    }
+    },
+    "uuid": "eac365fd-a811-47ab-9838-79b12db6d2b5"
   },
   "cross-icon-size-500": {
     "component": "icon",
@@ -775,7 +819,8 @@
         "value": "16px",
         "uuid": "a865d5f8-4798-4721-ab76-3b51067d6439"
       }
-    }
+    },
+    "uuid": "b2eff754-cfc5-4247-91b7-2f569c0114dd"
   },
   "cross-icon-size-600": {
     "component": "icon",
@@ -791,7 +836,8 @@
         "value": "18px",
         "uuid": "e12ac1ec-08f8-4d8b-8c4b-29b74cafe1a1"
       }
-    }
+    },
+    "uuid": "12fbc1b3-926f-419e-99f7-e42c7872c129"
   },
   "dash-icon-size-50": {
     "component": "icon",
@@ -807,7 +853,8 @@
         "value": "10px",
         "uuid": "ea331ff6-aa92-4cb4-936a-554a2404152d"
       }
-    }
+    },
+    "uuid": "f2859e6e-1d89-4b64-8d4d-dcfb11445164"
   },
   "dash-icon-size-75": {
     "component": "icon",
@@ -823,7 +870,8 @@
         "value": "10px",
         "uuid": "1b6d0e50-3ba2-43c9-8b8c-c220364f4434"
       }
-    }
+    },
+    "uuid": "0faea762-5ba2-4cd7-903c-776daa0cba6c"
   },
   "dash-icon-size-100": {
     "component": "icon",
@@ -839,7 +887,8 @@
         "value": "12px",
         "uuid": "9dc14737-973d-4f6e-8336-2e119c1f1af7"
       }
-    }
+    },
+    "uuid": "235518f5-3ded-4eaa-82e9-881cc76d2d02"
   },
   "dash-icon-size-200": {
     "component": "icon",
@@ -855,7 +904,8 @@
         "value": "14px",
         "uuid": "98ebf128-02f1-4d4b-a686-af8713a0f24b"
       }
-    }
+    },
+    "uuid": "45c3cf40-7250-4f8a-b25c-43550025fe8b"
   },
   "dash-icon-size-300": {
     "component": "icon",
@@ -871,7 +921,8 @@
         "value": "16px",
         "uuid": "ad59353e-3ed1-4e76-af87-020cebfa2664"
       }
-    }
+    },
+    "uuid": "0296d5a8-5022-43e0-91f4-465a174c0e33"
   },
   "dash-icon-size-400": {
     "component": "icon",
@@ -887,7 +938,8 @@
         "value": "18px",
         "uuid": "d2c45711-be18-4c85-8b23-f4d4f3d0b492"
       }
-    }
+    },
+    "uuid": "1967fd56-e60c-4994-ad5a-d84dc0f9c58f"
   },
   "dash-icon-size-500": {
     "component": "icon",
@@ -903,7 +955,8 @@
         "value": "20px",
         "uuid": "8d2ad303-095d-4f0c-b0c5-c1ec75b96819"
       }
-    }
+    },
+    "uuid": "5ae4eccd-7555-40c5-a59f-b17964d949ff"
   },
   "dash-icon-size-600": {
     "component": "icon",
@@ -919,6 +972,7 @@
         "value": "22px",
         "uuid": "2e81ce48-452d-401f-a44d-10ca427f031e"
       }
-    }
+    },
+    "uuid": "dc69f825-b868-4533-8ecc-1c17b4326f82"
   }
 }

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -16,7 +16,8 @@
             "value": "16px",
             "uuid": "af31c1a5-ffce-4a54-8862-3e711ca53d25"
           }
-        }
+        },
+        "uuid": "ee93bc59-4223-4538-9051-4fc0f78ade57"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -35,9 +36,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "13cd75f5-63de-4eb1-b3a6-528a9a853111"
           }
-        }
+        },
+        "uuid": "5d1fc913-cf08-43c0-94f9-62d538e3ac5d"
       }
-    }
+    },
+    "uuid": "3c21a6b5-0672-4e1c-b2a4-165ec6149b6d"
   },
   "checkbox-control-size-medium": {
     "component": "checkbox",
@@ -56,7 +59,8 @@
             "value": "18px",
             "uuid": "00fee3f7-a743-45d6-a2b6-028d5d96964a"
           }
-        }
+        },
+        "uuid": "0d7dbbdf-726c-4b38-ae5c-8aae4a76b385"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -75,9 +79,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "a4a66e58-f688-4b8e-bb22-66499697eebd"
           }
-        }
+        },
+        "uuid": "5938a3e2-01ae-49a5-b9b7-67bb1fcbf637"
       }
-    }
+    },
+    "uuid": "a0e56975-aaaa-4fa7-8dfe-b4d687f839cd"
   },
   "checkbox-control-size-large": {
     "component": "checkbox",
@@ -96,7 +102,8 @@
             "value": "20px",
             "uuid": "b4367578-989e-438d-9a3e-7cb077f2f7c9"
           }
-        }
+        },
+        "uuid": "c0fca44a-1dd6-43d8-bdeb-19964ba3f05f"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -115,9 +122,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "e91c542f-aab9-42e7-a92b-1019f0c2d83d"
           }
-        }
+        },
+        "uuid": "1c2ab94f-5e8b-4948-abf3-0ef29638a517"
       }
-    }
+    },
+    "uuid": "94305933-512a-480d-a44a-a0ba990d0626"
   },
   "checkbox-control-size-extra-large": {
     "component": "checkbox",
@@ -136,7 +145,8 @@
             "value": "22px",
             "uuid": "13093f8b-e38e-449f-a982-7f960bb84dfa"
           }
-        }
+        },
+        "uuid": "b38bbf4b-b515-4e5c-b339-1f604b865a9f"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -155,9 +165,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "028907b9-cfea-4464-8069-f796ff45871a"
           }
-        }
+        },
+        "uuid": "40515720-9283-41bb-aaeb-7cfbe90239fc"
       }
-    }
+    },
+    "uuid": "2f0c52c5-41b6-4d92-9345-50c448b9a79c"
   },
   "checkbox-top-to-control-small": {
     "component": "checkbox",
@@ -176,7 +188,8 @@
             "value": "7px",
             "uuid": "f254146e-f469-44b1-b0c9-1ac72e88f9e3"
           }
-        }
+        },
+        "uuid": "0218ee16-f0d6-4e66-b9e0-680827ef3804"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -195,9 +208,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "e3a31d3c-a3ef-4644-9ad0-ee6ee196f3fc"
           }
-        }
+        },
+        "uuid": "db12768c-90b0-479c-905b-ae9589f5a0d7"
       }
-    }
+    },
+    "uuid": "6293cb5a-79ce-4a80-8621-44b6e48175da"
   },
   "checkbox-top-to-control-medium": {
     "component": "checkbox",
@@ -216,7 +231,8 @@
             "value": "11px",
             "uuid": "e3751526-2db9-421c-85f9-d60071aac49b"
           }
-        }
+        },
+        "uuid": "f828021f-4a1f-466c-b11f-7b146bd36832"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -235,9 +251,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "19c53e39-2529-400e-849a-04210d29f022"
           }
-        }
+        },
+        "uuid": "3c1cc90f-0e1d-4e83-afe9-7677e7ad39c6"
       }
-    }
+    },
+    "uuid": "278b4c19-a365-465d-9169-f07611b0e6a4"
   },
   "checkbox-top-to-control-large": {
     "component": "checkbox",
@@ -256,7 +274,8 @@
             "value": "15px",
             "uuid": "d040d2f4-9bb4-4d27-adac-40fef079d958"
           }
-        }
+        },
+        "uuid": "fb853ce5-65d1-475b-9867-0e71d4af9536"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -275,9 +294,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "9952f0e9-8cf1-4a72-a584-99fe4b708b0e"
           }
-        }
+        },
+        "uuid": "f94fe1d8-a682-45b9-b005-1121b8788e67"
       }
-    }
+    },
+    "uuid": "4d8d78c3-4f20-480a-9b92-bfa2ecd6d7ab"
   },
   "checkbox-top-to-control-extra-large": {
     "component": "checkbox",
@@ -296,7 +317,8 @@
             "value": "19px",
             "uuid": "b3be5ac8-2415-4490-8b4a-c08661ec84d1"
           }
-        }
+        },
+        "uuid": "77e9a03f-4936-43ca-8558-70d0f648618b"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -315,9 +337,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "f21573b4-a8e6-4209-9bc0-6030a542308f"
           }
-        }
+        },
+        "uuid": "f3bd16e7-db20-463b-89df-82886b0e7ef7"
       }
-    }
+    },
+    "uuid": "28800a46-8103-4a0c-9e9e-753ecccd8160"
   },
   "switch-control-width-small": {
     "component": "switch",
@@ -336,7 +360,8 @@
             "value": "32px",
             "uuid": "ca939c4d-9369-498c-81cb-61df1397f657"
           }
-        }
+        },
+        "uuid": "0c641ef6-cd8b-4183-9ea9-29b3f30b90b2"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -355,9 +380,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "76c9ee44-720a-4ce0-88a5-15d93c6f9e32"
           }
-        }
+        },
+        "uuid": "0719f43a-aa80-498b-8167-66bfa30d6fef"
       }
-    }
+    },
+    "uuid": "8522cca3-2174-4d2f-96d8-443a4346442b"
   },
   "switch-control-width-medium": {
     "component": "switch",
@@ -376,7 +403,8 @@
             "value": "36px",
             "uuid": "ec2f3b6b-80db-4c43-bdd2-caee98796775"
           }
-        }
+        },
+        "uuid": "a10c659f-6fb9-4cde-b996-42fa1e94d758"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -395,9 +423,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "bd5c5024-4e29-4aef-86e4-6a4f7568ca2f"
           }
-        }
+        },
+        "uuid": "06a0ba1f-a914-4f9c-bade-1e930bb5273a"
       }
-    }
+    },
+    "uuid": "22eb4f1e-4fbc-4088-8296-6abf56cb0126"
   },
   "switch-control-width-large": {
     "component": "switch",
@@ -416,7 +446,8 @@
             "value": "41px",
             "uuid": "5c7bdcc9-63f8-4c4b-b26f-97b39f53dbea"
           }
-        }
+        },
+        "uuid": "f9e23291-6110-4770-abeb-ec1bd6ef529c"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -435,9 +466,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "5fa423b6-faa2-497e-9bbd-59cac5c9c696"
           }
-        }
+        },
+        "uuid": "06cb2cd0-e437-48d4-850e-c6bb70f6bac5"
       }
-    }
+    },
+    "uuid": "76311a72-2906-46c2-bd2f-e1cf55a1761c"
   },
   "switch-control-width-extra-large": {
     "component": "switch",
@@ -456,7 +489,8 @@
             "value": "46px",
             "uuid": "4e9d9b63-989a-4b63-b74d-22b5188f8df7"
           }
-        }
+        },
+        "uuid": "28d7a626-dbbf-401b-8c7b-5fa59f54242e"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -475,9 +509,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "0f253bb1-11d1-4af3-901b-b7b4877d02fa"
           }
-        }
+        },
+        "uuid": "6347a50c-ab8c-474c-b023-f240971a8dd3"
       }
-    }
+    },
+    "uuid": "74704e52-a27a-4542-9172-21c7e8e94e01"
   },
   "switch-control-height-small": {
     "component": "switch",
@@ -496,7 +532,8 @@
             "value": "16px",
             "uuid": "a1dbcaf0-bbcf-444d-9d22-7f86db20303a"
           }
-        }
+        },
+        "uuid": "a795d784-a67e-4689-8a30-029f096703b0"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -515,9 +552,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "a0df76f3-334c-404e-af94-651dc1631551"
           }
-        }
+        },
+        "uuid": "dd76c4a0-5a57-4285-9dd7-9ce340373a1b"
       }
-    }
+    },
+    "uuid": "98407df8-86cd-4c7e-a1f5-ac658f3acac0"
   },
   "switch-control-height-medium": {
     "component": "switch",
@@ -536,7 +575,8 @@
             "value": "18px",
             "uuid": "0d5f13f2-4d5b-4c30-b3a3-fa4fcc33b928"
           }
-        }
+        },
+        "uuid": "d723ac24-d571-4680-85a2-df9bad339742"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -555,9 +595,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "4d30aa11-6dfd-4049-97fb-becec10241d6"
           }
-        }
+        },
+        "uuid": "3278cc86-d59d-4316-a4bd-4f7dd2a6d360"
       }
-    }
+    },
+    "uuid": "fa372672-47db-4a93-9c3f-9736305f8bfc"
   },
   "switch-control-height-large": {
     "component": "switch",
@@ -576,7 +618,8 @@
             "value": "20px",
             "uuid": "91b828ce-8ff9-4d32-958e-a8a23ef9b345"
           }
-        }
+        },
+        "uuid": "888da305-52db-492c-9133-1888ea0a0fe6"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -595,9 +638,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "db3ec089-c51c-48f6-9f3e-0588173bb5f2"
           }
-        }
+        },
+        "uuid": "0f36a04c-8562-4cff-a1a4-0a16143eeeb4"
       }
-    }
+    },
+    "uuid": "c4264736-04eb-4f9c-a26b-f77dfc9af0fe"
   },
   "switch-control-height-extra-large": {
     "component": "switch",
@@ -616,7 +661,8 @@
             "value": "22px",
             "uuid": "b7ae7b32-b347-4e09-9978-3b0b92a4dbab"
           }
-        }
+        },
+        "uuid": "bdae73c7-1606-4388-a35f-fde686f340f9"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -635,9 +681,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "00e246ce-9510-4429-bbc9-74b442865798"
           }
-        }
+        },
+        "uuid": "f4770609-e927-4689-92eb-81b4b0667519"
       }
-    }
+    },
+    "uuid": "3c695f82-7648-4565-85a9-c2aa0b5f0c83"
   },
   "switch-top-to-control-small": {
     "component": "switch",
@@ -656,7 +704,8 @@
             "value": "7px",
             "uuid": "f379c453-da21-41f6-92d1-9b6bdb95fd86"
           }
-        }
+        },
+        "uuid": "38308100-a1fc-45bb-9aa6-a5aca196e168"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -675,9 +724,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "85c920b2-1f23-4bf1-90ae-e5c92d854c77"
           }
-        }
+        },
+        "uuid": "bc106555-0cda-4550-927a-671ae62b8adb"
       }
-    }
+    },
+    "uuid": "5eb5b6a0-48fc-4200-8497-55db7da7e135"
   },
   "switch-top-to-control-medium": {
     "component": "switch",
@@ -696,7 +747,8 @@
             "value": "11px",
             "uuid": "68276028-41d8-49e1-b0d4-f70cd27ab149"
           }
-        }
+        },
+        "uuid": "c179855f-8577-4f10-9c9d-a2e822c30022"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -715,9 +767,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "7ba17c8b-51a1-47e3-a3be-7c8a746ab04c"
           }
-        }
+        },
+        "uuid": "d5370d57-4b1c-4cca-8c6d-d54bb4219d5e"
       }
-    }
+    },
+    "uuid": "aca3a431-36b6-43b9-b0b0-d64e84c350d4"
   },
   "switch-top-to-control-large": {
     "component": "switch",
@@ -736,7 +790,8 @@
             "value": "15px",
             "uuid": "035e786b-17f2-488e-a049-84b257a3312f"
           }
-        }
+        },
+        "uuid": "162f29ee-4f53-4947-81a3-3c0e003f7997"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -755,9 +810,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "43037e51-b895-4599-9d67-afcd17b0d9de"
           }
-        }
+        },
+        "uuid": "f5f708d8-967d-427d-9ea2-6617b4d9f28d"
       }
-    }
+    },
+    "uuid": "c701b308-8f16-4ea1-8654-72a2779f7500"
   },
   "switch-top-to-control-extra-large": {
     "component": "switch",
@@ -776,7 +833,8 @@
             "value": "19px",
             "uuid": "7e95ad9a-ca10-4f06-9c19-8dd2270cfdad"
           }
-        }
+        },
+        "uuid": "0b6d95f7-8c05-4d78-83b9-f74bae363c32"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -795,9 +853,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "67f76075-33fb-4cbf-8785-cb1d626d2a04"
           }
-        }
+        },
+        "uuid": "1f74569f-7529-4a33-ba04-36ee1fdb9a95"
       }
-    }
+    },
+    "uuid": "89647edb-2cce-4be8-9644-e78d292d8d71"
   },
   "radio-button-control-size-small": {
     "component": "radio-button",
@@ -816,7 +876,8 @@
             "value": "16px",
             "uuid": "90a2b18a-61c7-40d8-926c-d6b18a641010"
           }
-        }
+        },
+        "uuid": "b934fcbd-f58e-4b8b-a890-698920829d3e"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -835,9 +896,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "cf3edaa4-3897-491a-add0-53f8057925da"
           }
-        }
+        },
+        "uuid": "b122f7a1-df01-4c68-b980-cbcecf201307"
       }
-    }
+    },
+    "uuid": "55afc37a-81ce-4065-96ca-556fc49e43bf"
   },
   "radio-button-control-size-medium": {
     "component": "radio-button",
@@ -856,7 +919,8 @@
             "value": "18px",
             "uuid": "2eef4003-e666-48e7-b25b-8c50063ce400"
           }
-        }
+        },
+        "uuid": "6926490d-dc56-4ca2-b733-848ea6a132da"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -875,9 +939,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "ae670151-1eaa-4de5-9a67-2e7a553b7b63"
           }
-        }
+        },
+        "uuid": "7a50d806-bba1-45a0-bfb2-2d71b0086c09"
       }
-    }
+    },
+    "uuid": "20f7aebf-f4c1-4e18-87a1-3726eb475b45"
   },
   "radio-button-control-size-large": {
     "component": "radio-button",
@@ -896,7 +962,8 @@
             "value": "20px",
             "uuid": "23d0a4aa-693d-4b79-b942-3898f9cf0b80"
           }
-        }
+        },
+        "uuid": "1f303f57-24c3-447f-a2b8-3f9ff9d9bef0"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -915,9 +982,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "2d0cb7dc-68e0-4e88-a2eb-5b4feac5c800"
           }
-        }
+        },
+        "uuid": "4074251c-034d-4eff-916f-1cf3ac39e175"
       }
-    }
+    },
+    "uuid": "d12c6733-a8bc-4dac-8a02-b876a53509ce"
   },
   "radio-button-control-size-extra-large": {
     "component": "radio-button",
@@ -936,7 +1005,8 @@
             "value": "22px",
             "uuid": "cc041f48-aaa4-4c20-8990-599e0c56134e"
           }
-        }
+        },
+        "uuid": "30ff09c2-c18c-4dfa-bb30-361640e478c1"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -955,9 +1025,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "c5f734ba-bf7a-4b64-8d70-8109fead6a90"
           }
-        }
+        },
+        "uuid": "70167288-2023-4c23-bf26-420501bae9c2"
       }
-    }
+    },
+    "uuid": "68b995ce-bbd8-44ba-9d72-df121fdfdd89"
   },
   "radio-button-top-to-control-small": {
     "component": "radio-button",
@@ -976,7 +1048,8 @@
             "value": "7px",
             "uuid": "02438c4c-161d-45eb-935d-b083ab830876"
           }
-        }
+        },
+        "uuid": "e8ec5366-9291-4c0f-9522-10367b2e5b2d"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -995,9 +1068,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "39ae9b23-fc0d-45d7-beaa-42e7489fbd6e"
           }
-        }
+        },
+        "uuid": "bb480f70-b3da-4158-bfac-2c59301f5acf"
       }
-    }
+    },
+    "uuid": "2d2f9e65-7ced-446f-9592-fe7bf530cf62"
   },
   "radio-button-top-to-control-medium": {
     "component": "radio-button",
@@ -1016,7 +1091,8 @@
             "value": "11px",
             "uuid": "2f805530-cefe-420a-89e6-a6a81c0faea0"
           }
-        }
+        },
+        "uuid": "c43d7fdb-420e-4909-a6ee-795495cb7c9d"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1035,9 +1111,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "8629a0e6-b0bc-4447-b17d-8717b766579c"
           }
-        }
+        },
+        "uuid": "c91222de-62f2-4c42-a50e-87827f06d9ec"
       }
-    }
+    },
+    "uuid": "783325cf-300a-46e3-baad-4b865c6df12f"
   },
   "radio-button-top-to-control-large": {
     "component": "radio-button",
@@ -1056,7 +1134,8 @@
             "value": "15px",
             "uuid": "41d0dde7-de34-4e99-96d0-4f727ed71673"
           }
-        }
+        },
+        "uuid": "8283fca4-caa5-4262-a626-85fffa65d9fb"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1075,9 +1154,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "9db66e19-9553-47ca-ac5c-118a6b5f043a"
           }
-        }
+        },
+        "uuid": "1e2896f0-3910-4a1e-8557-7929040f0155"
       }
-    }
+    },
+    "uuid": "e114b720-a1ad-4394-b8ce-6622d9886f8e"
   },
   "radio-button-top-to-control-extra-large": {
     "component": "radio-button",
@@ -1096,7 +1177,8 @@
             "value": "19px",
             "uuid": "c478710f-1747-455b-998a-6fa837762905"
           }
-        }
+        },
+        "uuid": "dbeeb464-daab-4ac3-ab0c-63d3f0415554"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1115,9 +1197,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "42768b7d-b75d-4236-a8d3-e14d1d6e6f55"
           }
-        }
+        },
+        "uuid": "59e82c86-c8d7-4c47-8151-7e3efef51101"
       }
-    }
+    },
+    "uuid": "741e1396-c77c-4ac8-8292-eb11963ef18b"
   },
   "radio-button-selection-indicator": {
     "component": "radio-button",
@@ -1139,7 +1223,8 @@
         "value": "5px",
         "uuid": "4271498d-747c-423d-87cc-761b8a181f7c"
       }
-    }
+    },
+    "uuid": "a02163f0-6509-4b95-9d41-9d992ac5deef"
   },
   "field-label-text-to-asterisk-medium": {
     "component": "field-label",
@@ -1155,7 +1240,8 @@
         "value": "5px",
         "uuid": "2fbc4add-e6b4-4dfa-9a7d-0de628b2f63c"
       }
-    }
+    },
+    "uuid": "2aab2a3d-b2d4-49f8-9467-4e35d3564637"
   },
   "field-label-text-to-asterisk-large": {
     "component": "field-label",
@@ -1171,7 +1257,8 @@
         "value": "6px",
         "uuid": "87149afe-899b-4fb6-bd7c-d2becf8117fc"
       }
-    }
+    },
+    "uuid": "671e4951-7e50-4dec-aff1-2833deb6a950"
   },
   "field-label-text-to-asterisk-extra-large": {
     "component": "field-label",
@@ -1187,7 +1274,8 @@
         "value": "6px",
         "uuid": "17ba788d-da38-455d-9322-16e4f05ea923"
       }
-    }
+    },
+    "uuid": "9b85fe75-9b6c-47e7-bfbe-dddfcdfdac79"
   },
   "field-label-top-to-asterisk-small": {
     "component": "field-label",
@@ -1203,7 +1291,8 @@
         "value": "11px",
         "uuid": "ec0c072f-50fb-4934-99fc-a2576062e7b4"
       }
-    }
+    },
+    "uuid": "376801d0-554e-4889-91f4-cad3a023e486"
   },
   "field-label-top-to-asterisk-medium": {
     "component": "field-label",
@@ -1219,7 +1308,8 @@
         "value": "15px",
         "uuid": "6f65ad1a-4a65-4b83-af44-5bd893f3b40e"
       }
-    }
+    },
+    "uuid": "b7d0b135-04ad-43fd-ad0e-ef9675c855dd"
   },
   "field-label-top-to-asterisk-large": {
     "component": "field-label",
@@ -1235,7 +1325,8 @@
         "value": "19px",
         "uuid": "e410a804-2655-4bbc-9b66-53a5facc92ac"
       }
-    }
+    },
+    "uuid": "301d5efa-c1b8-476d-897b-75f4988c99e3"
   },
   "field-label-top-to-asterisk-extra-large": {
     "component": "field-label",
@@ -1251,7 +1342,8 @@
         "value": "24px",
         "uuid": "5227bf07-140a-49c6-88f9-cc454d8a90c1"
       }
-    }
+    },
+    "uuid": "aaabc5b5-73a3-4d26-8a44-932981634cbd"
   },
   "field-label-top-margin-small": {
     "component": "field-label",
@@ -1273,7 +1365,8 @@
         "value": "5px",
         "uuid": "9d00a023-3a33-4b98-819e-3229e03d103b"
       }
-    }
+    },
+    "uuid": "2e307771-487d-494a-97bb-ada56c157c60"
   },
   "field-label-top-margin-large": {
     "component": "field-label",
@@ -1289,7 +1382,8 @@
         "value": "6px",
         "uuid": "f83b208f-dfdb-49a8-aedd-08fe8c7a86a9"
       }
-    }
+    },
+    "uuid": "11679297-ddb6-43b6-870c-66bccaf9efb1"
   },
   "field-label-top-margin-extra-large": {
     "component": "field-label",
@@ -1305,7 +1399,8 @@
         "value": "6px",
         "uuid": "c4c5e251-d514-42cf-b9e3-56694910e95b"
       }
-    }
+    },
+    "uuid": "0d2b575a-2d70-40b1-b3c0-562a64529e81"
   },
   "field-label-to-component": {
     "component": "field-label",
@@ -1327,7 +1422,8 @@
         "value": "-10px",
         "uuid": "2d3e67ce-de6d-4e41-bcf8-06b09c0bcce7"
       }
-    }
+    },
+    "uuid": "c29a472d-800e-4d65-b493-5a635047bd64"
   },
   "field-label-to-component-quiet-medium": {
     "component": "field-label",
@@ -1343,7 +1439,8 @@
         "value": "-10px",
         "uuid": "074489d2-66b0-4198-94fe-9818279bbf0f"
       }
-    }
+    },
+    "uuid": "1805d2b6-66ab-40aa-9410-60ed20fe0bfd"
   },
   "field-label-to-component-quiet-large": {
     "component": "field-label",
@@ -1359,7 +1456,8 @@
         "value": "-15px",
         "uuid": "c29cfb87-34e7-4397-bfd8-23378ecbb011"
       }
-    }
+    },
+    "uuid": "a8efae7b-e0b5-4816-89d3-25fc716580f2"
   },
   "field-label-to-component-quiet-extra-large": {
     "component": "field-label",
@@ -1375,7 +1473,8 @@
         "value": "-19px",
         "uuid": "e1298748-d7cc-4bff-93bc-745b777fcf9e"
       }
-    }
+    },
+    "uuid": "4d4dbbb1-4d22-4803-836f-8b89a8794302"
   },
   "help-text-top-to-workflow-icon-small": {
     "component": "help-text",
@@ -1391,7 +1490,8 @@
         "value": "5px",
         "uuid": "00334ebf-5706-4a97-b02c-9f41642c4795"
       }
-    }
+    },
+    "uuid": "031892d3-31f2-433f-bed0-72c5b3ab0432"
   },
   "help-text-top-to-workflow-icon-medium": {
     "component": "help-text",
@@ -1407,7 +1507,8 @@
         "value": "4px",
         "uuid": "b690bd12-855e-444d-8b76-a7ae948e3f52"
       }
-    }
+    },
+    "uuid": "86ac0bd3-7ea6-4f80-9c73-c0c77616f246"
   },
   "help-text-top-to-workflow-icon-large": {
     "component": "help-text",
@@ -1423,7 +1524,8 @@
         "value": "8px",
         "uuid": "e2c40309-5b3d-485a-bafa-9015a5b751e7"
       }
-    }
+    },
+    "uuid": "e5517e20-dd37-4e43-9880-6042eb4c91bb"
   },
   "help-text-top-to-workflow-icon-extra-large": {
     "component": "help-text",
@@ -1439,7 +1541,8 @@
         "value": "11px",
         "uuid": "251c39cc-f949-4055-aecb-42fc99f9d504"
       }
-    }
+    },
+    "uuid": "2969e536-134d-462c-b7c3-2bd4490ce23c"
   },
   "help-text-to-component": {
     "component": "help-text",
@@ -1467,7 +1570,8 @@
         "value": "10px",
         "uuid": "a7fc9ca1-ad6d-47cb-8798-4a18ba4acc79"
       }
-    }
+    },
+    "uuid": "268c4731-1c52-47e1-b50d-e17b0fb1b1aa"
   },
   "status-light-dot-size-large": {
     "component": "status-light",
@@ -1483,7 +1587,8 @@
         "value": "12px",
         "uuid": "6554dae9-18b6-4c90-b2f4-8aeaab0724ad"
       }
-    }
+    },
+    "uuid": "1de5181f-8fb5-4123-85dd-c06a1382865f"
   },
   "status-light-dot-size-extra-large": {
     "component": "status-light",
@@ -1499,7 +1604,8 @@
         "value": "12px",
         "uuid": "38b8d9c8-d340-4123-88bc-f739cfde91e9"
       }
-    }
+    },
+    "uuid": "c1561e03-afdd-4c60-ba43-9c850aefd20a"
   },
   "status-light-top-to-dot-small": {
     "component": "status-light",
@@ -1515,7 +1621,8 @@
         "value": "11px",
         "uuid": "a4f43adc-1db1-4e2f-a5d1-3ec06c62c9ff"
       }
-    }
+    },
+    "uuid": "dcb4e3bd-ebee-45d9-ad30-c91307c7a0a5"
   },
   "status-light-top-to-dot-medium": {
     "component": "status-light",
@@ -1531,7 +1638,8 @@
         "value": "15px",
         "uuid": "321a462b-8811-4264-ac1f-4608df8f8c53"
       }
-    }
+    },
+    "uuid": "2e620445-18c0-4fdf-9d6b-ba05960cb254"
   },
   "status-light-top-to-dot-large": {
     "component": "status-light",
@@ -1547,7 +1655,8 @@
         "value": "19px",
         "uuid": "8d9d872f-7c55-4a94-a80d-c1f2c8834f5d"
       }
-    }
+    },
+    "uuid": "abebffcd-877a-40ed-b538-10928353d74e"
   },
   "status-light-top-to-dot-extra-large": {
     "component": "status-light",
@@ -1563,7 +1672,8 @@
         "value": "24px",
         "uuid": "b351cade-6d69-449e-908a-518793fef5b9"
       }
-    }
+    },
+    "uuid": "a8230bf5-89c7-4056-b8c7-29994e5524a0"
   },
   "action-button-edge-to-hold-icon-extra-small": {
     "component": "action-button",
@@ -1591,7 +1701,8 @@
         "value": "5px",
         "uuid": "255a24ab-f70d-4698-8d2e-569c37c6c798"
       }
-    }
+    },
+    "uuid": "2ffb06a4-6d3e-4b04-ab4e-53c8af557540"
   },
   "action-button-edge-to-hold-icon-large": {
     "component": "action-button",
@@ -1607,7 +1718,8 @@
         "value": "6px",
         "uuid": "86a36757-a2d1-4263-97dc-62cf4543b3f9"
       }
-    }
+    },
+    "uuid": "8c025c63-8f5a-43b7-a1d7-658ca92409ff"
   },
   "action-button-edge-to-hold-icon-extra-large": {
     "component": "action-button",
@@ -1623,7 +1735,8 @@
         "value": "7px",
         "uuid": "b4b4710b-2073-4285-8342-31ae6712671b"
       }
-    }
+    },
+    "uuid": "40e6526a-67c3-42b4-994e-6d30184dbfd0"
   },
   "button-minimum-width-multiplier": {
     "component": "button",
@@ -1645,7 +1758,8 @@
         "value": "10px",
         "uuid": "ad2c09a6-c42e-4eef-94a3-6c2180c6e2af"
       }
-    }
+    },
+    "uuid": "a3e2c245-2819-491f-81d1-4455746231b0"
   },
   "tooltip-tip-height": {
     "component": "tooltip",
@@ -1661,7 +1775,8 @@
         "value": "5px",
         "uuid": "70c9f65f-1e23-4c47-94dd-0c3ddde15743"
       }
-    }
+    },
+    "uuid": "c91eb240-75de-47f2-ada0-c4fa48b4a062"
   },
   "tooltip-maximum-width": {
     "component": "tooltip",
@@ -1677,7 +1792,8 @@
         "value": "200px",
         "uuid": "6d7623e1-65f5-4af5-8c08-b33b093b85ae"
       }
-    }
+    },
+    "uuid": "02a0befa-2079-4104-b00e-08f6e41648fa"
   },
   "divider-thickness-small": {
     "component": "divider",
@@ -1711,7 +1827,8 @@
         "value": "20px",
         "uuid": "a7fafd60-dc38-425a-b6b6-952a06d30ab4"
       }
-    }
+    },
+    "uuid": "80dfceb1-2bd0-49a5-b1e4-c5ec0f1717b4"
   },
   "progress-circle-size-medium": {
     "component": "progress-circle",
@@ -1727,7 +1844,8 @@
         "value": "40px",
         "uuid": "c380cf9b-cb59-465c-9b56-41654d3239f1"
       }
-    }
+    },
+    "uuid": "5ebff1b9-30c0-42ef-854a-d24dd35e5a73"
   },
   "progress-circle-size-large": {
     "component": "progress-circle",
@@ -1743,7 +1861,8 @@
         "value": "80px",
         "uuid": "c7719369-7d3d-4446-ade2-08abb472a985"
       }
-    }
+    },
+    "uuid": "75855fb6-77c1-4bf0-b7a7-cdcea70fe114"
   },
   "progress-circle-thickness-small": {
     "component": "progress-circle",
@@ -1759,7 +1878,8 @@
         "value": "3px",
         "uuid": "a37ef752-662b-4152-b247-0ce9fcd624e4"
       }
-    }
+    },
+    "uuid": "243aff09-e196-4c70-94fc-9b2bc7f0eaf5"
   },
   "progress-circle-thickness-medium": {
     "component": "progress-circle",
@@ -1775,7 +1895,8 @@
         "value": "4px",
         "uuid": "aa930d94-7874-44d7-80f1-dc431d40c4a4"
       }
-    }
+    },
+    "uuid": "16e18a45-36dd-49e6-8f7a-9f98b2d43f1e"
   },
   "progress-circle-thickness-large": {
     "component": "progress-circle",
@@ -1791,7 +1912,8 @@
         "value": "5px",
         "uuid": "076b031f-5980-4112-bf0b-2cec47f54c6b"
       }
-    }
+    },
+    "uuid": "aec2d866-6282-40e2-a3ac-62cb7972aac8"
   },
   "toast-height": {
     "component": "toast",
@@ -1807,7 +1929,8 @@
         "value": "56px",
         "uuid": "12c8ae92-16b9-48ec-801c-bf07785da4b3"
       }
-    }
+    },
+    "uuid": "616ccaf7-d757-45f0-b212-782d7bee21fd"
   },
   "toast-maximum-width": {
     "component": "toast",
@@ -1823,7 +1946,8 @@
         "value": "420px",
         "uuid": "a4de5997-1eb1-430f-9a9f-cf2637d02d34"
       }
-    }
+    },
+    "uuid": "a1b4c509-39db-436f-bece-147fe30760a7"
   },
   "toast-top-to-workflow-icon": {
     "component": "toast",
@@ -1839,7 +1963,8 @@
         "value": "17px",
         "uuid": "1f83245b-3d79-4326-b843-df7b6549cade"
       }
-    }
+    },
+    "uuid": "657689f7-d729-4707-9939-2006a8f55397"
   },
   "toast-top-to-text": {
     "component": "toast",
@@ -1855,7 +1980,8 @@
         "value": "16px",
         "uuid": "9f0688f5-128f-47c3-8585-94d704214881"
       }
-    }
+    },
+    "uuid": "3654a646-a72d-4e5e-aec7-c388d21edf7f"
   },
   "toast-bottom-to-text": {
     "component": "toast",
@@ -1871,7 +1997,8 @@
         "value": "19px",
         "uuid": "a790fd9e-4e5f-4f4c-a3ca-832540832580"
       }
-    }
+    },
+    "uuid": "01851120-86da-4060-9473-af6a6a3de7f5"
   },
   "action-bar-height": {
     "component": "action-bar",
@@ -1887,7 +2014,8 @@
         "value": "56px",
         "uuid": "4be2cf45-1ba5-4a6f-a004-8d26ecbb4c2f"
       }
-    }
+    },
+    "uuid": "62695212-bc5e-4c3a-93c9-f4e112ef5117"
   },
   "action-bar-top-to-item-counter": {
     "component": "action-bar",
@@ -1903,7 +2031,8 @@
         "value": "16px",
         "uuid": "b8466a83-3409-47c0-a329-b8e83b83abdb"
       }
-    }
+    },
+    "uuid": "ec663da9-b374-477d-9222-cce2682bfaa5"
   },
   "swatch-size-extra-small": {
     "component": "swatch",
@@ -1919,7 +2048,8 @@
         "value": "20px",
         "uuid": "0d926e1a-080a-41ba-8bb9-ef6d0847cb77"
       }
-    }
+    },
+    "uuid": "09fcadd8-5a2b-4a12-a6c9-9c21f119ddc7"
   },
   "swatch-size-small": {
     "component": "swatch",
@@ -1935,7 +2065,8 @@
         "value": "30px",
         "uuid": "c8d8e379-1e3f-4f5e-bce3-df3fc05ff16e"
       }
-    }
+    },
+    "uuid": "b4e9a9b9-ced1-4dc9-bb56-ee4f5aeb3824"
   },
   "swatch-size-medium": {
     "component": "swatch",
@@ -1951,7 +2082,8 @@
         "value": "40px",
         "uuid": "77be7e79-a589-4f32-9e42-ea45ed7763aa"
       }
-    }
+    },
+    "uuid": "1b03fbc4-00a7-45cd-b328-f7180743a7bc"
   },
   "swatch-size-large": {
     "component": "swatch",
@@ -1967,7 +2099,8 @@
         "value": "50px",
         "uuid": "162c1233-3420-44a2-a270-97d0a7c23df1"
       }
-    }
+    },
+    "uuid": "2544beb5-a218-4fbe-992d-b282a732e7ed"
   },
   "swatch-rectangle-width-multiplier": {
     "component": "swatch",
@@ -2025,7 +2158,8 @@
         "value": "5px",
         "uuid": "ab98c47f-f2e4-4f74-8008-55c65907b6eb"
       }
-    }
+    },
+    "uuid": "a5bf84aa-2719-4204-b9f1-e7463ad010da"
   },
   "progress-bar-thickness-medium": {
     "component": "progress-bar",
@@ -2041,7 +2175,8 @@
         "value": "8px",
         "uuid": "d53e3ac6-6091-4c3f-9e1b-b12b716a5f95"
       }
-    }
+    },
+    "uuid": "76bb6912-2bca-493f-a198-20aa7e1636b3"
   },
   "progress-bar-thickness-large": {
     "component": "progress-bar",
@@ -2057,7 +2192,8 @@
         "value": "10px",
         "uuid": "4b680695-7e42-493c-889b-c76a60ab1f4f"
       }
-    }
+    },
+    "uuid": "2f57822d-5feb-425c-b76a-d2d393c4ee8e"
   },
   "progress-bar-thickness-extra-large": {
     "component": "progress-bar",
@@ -2073,7 +2209,8 @@
         "value": "13px",
         "uuid": "c15e51b3-4a5e-421e-aa4e-e0a82840f1a2"
       }
-    }
+    },
+    "uuid": "83950b17-a2f2-404c-a76c-74bf43c0f663"
   },
   "meter-minimum-width": {
     "component": "meter",
@@ -2101,7 +2238,8 @@
         "value": "240px",
         "uuid": "dc5f4966-4ddd-4e9a-a748-370d8eaae568"
       }
-    }
+    },
+    "uuid": "25d19f48-7ab7-4176-b745-0bef75ebfe44"
   },
   "meter-default-width": {
     "component": "meter",
@@ -2125,7 +2263,8 @@
         "value": "5px",
         "uuid": "eb9c3cff-5a1a-4832-a623-6ab258b81d37"
       }
-    }
+    },
+    "uuid": "c4e3b88c-9539-4741-a5ea-0e84953dc499"
   },
   "meter-thickness-large": {
     "component": "meter",
@@ -2141,7 +2280,8 @@
         "value": "8px",
         "uuid": "c9052808-918e-4368-b113-28f928104eda"
       }
-    }
+    },
+    "uuid": "9e406a2a-3456-4d9d-8ad8-21ab27ec1be2"
   },
   "in-line-alert-minimum-width": {
     "component": "in-line-alert",
@@ -2163,7 +2303,8 @@
         "value": "5px",
         "uuid": "a2c40238-1fda-4482-a419-b8092a385c9b"
       }
-    }
+    },
+    "uuid": "e493f30d-e05e-46bd-80ec-cfe84fa0a5b5"
   },
   "tag-top-to-avatar-medium": {
     "component": "tag",
@@ -2179,7 +2320,8 @@
         "value": "7px",
         "uuid": "8dbabe33-52e7-4dc1-b2e3-81c1c62d98cb"
       }
-    }
+    },
+    "uuid": "10f21fe1-6310-43a0-bdf1-0b4543914cf1"
   },
   "tag-top-to-avatar-large": {
     "component": "tag",
@@ -2195,7 +2337,8 @@
         "value": "11px",
         "uuid": "9881ad7c-e9df-40b1-a368-4f8185042c3f"
       }
-    }
+    },
+    "uuid": "b5b37323-fd9a-4f63-a222-9587cf71bfd0"
   },
   "tag-top-to-cross-icon-small": {
     "component": "tag",
@@ -2211,7 +2354,8 @@
         "value": "10px",
         "uuid": "d93e04b9-1901-4ec4-947a-62c84205e61e"
       }
-    }
+    },
+    "uuid": "ca9917ec-e850-41f6-84af-496734f8a540"
   },
   "tag-top-to-cross-icon-medium": {
     "component": "tag",
@@ -2227,7 +2371,8 @@
         "value": "15px",
         "uuid": "ac7b17a2-99ef-45b3-ab3b-4d3eeaf99fb9"
       }
-    }
+    },
+    "uuid": "7cbb04dd-d793-4749-b6f2-61a265b64787"
   },
   "tag-top-to-cross-icon-large": {
     "component": "tag",
@@ -2243,7 +2388,8 @@
         "value": "19px",
         "uuid": "af69e3d1-92b6-4e62-93f2-c1f1f10f0a63"
       }
-    }
+    },
+    "uuid": "7672a296-b875-4076-b342-695ff110246c"
   },
   "popover-tip-width": {
     "component": "popover",
@@ -2271,7 +2417,8 @@
         "value": "5px",
         "uuid": "6165bae4-7148-4cb2-a1b4-38a25f2d8cde"
       }
-    }
+    },
+    "uuid": "8b388882-bd89-46cb-882b-f3198e4af710"
   },
   "menu-item-label-to-description": {
     "component": "menu",
@@ -2293,7 +2440,8 @@
         "value": "24px",
         "uuid": "de2ef572-54a2-46c2-ad1d-60468fbe6090"
       }
-    }
+    },
+    "uuid": "6e23f979-9b82-4273-9221-b54a69fc4d99"
   },
   "menu-item-edge-to-content-not-selected-medium": {
     "component": "menu",
@@ -2309,7 +2457,8 @@
         "value": "42px",
         "uuid": "5faa4858-5590-40d4-bd12-b4c839908c4c"
       }
-    }
+    },
+    "uuid": "d05d20d8-2ad8-4a2a-880f-5f14c7c2907e"
   },
   "menu-item-edge-to-content-not-selected-large": {
     "component": "menu",
@@ -2325,7 +2474,8 @@
         "value": "47px",
         "uuid": "90385dcc-ea45-466f-ba4d-a1b13f6a079c"
       }
-    }
+    },
+    "uuid": "9d0e4967-c42d-4366-9e0e-5f75b3b1ee30"
   },
   "menu-item-edge-to-content-not-selected-extra-large": {
     "component": "menu",
@@ -2341,7 +2491,8 @@
         "value": "54px",
         "uuid": "3385c12f-199b-4e9d-b2e2-ef6e2658d180"
       }
-    }
+    },
+    "uuid": "8d03e277-4105-45b0-adb6-d31d03a325dc"
   },
   "menu-item-top-to-disclosure-icon-small": {
     "component": "menu",
@@ -2357,7 +2508,8 @@
         "value": "9px",
         "uuid": "eb9cf950-cba2-4fb8-a115-8a4c0ddb00d0"
       }
-    }
+    },
+    "uuid": "4fbc0a14-95ad-44d6-81d1-1115267dd83d"
   },
   "menu-item-top-to-disclosure-icon-medium": {
     "component": "menu",
@@ -2373,7 +2525,8 @@
         "value": "13px",
         "uuid": "e0468683-b2d2-4839-9ad8-46963d7402fc"
       }
-    }
+    },
+    "uuid": "0609f98d-936d-49df-905c-8d8beebbf900"
   },
   "menu-item-top-to-disclosure-icon-large": {
     "component": "menu",
@@ -2389,7 +2542,8 @@
         "value": "17px",
         "uuid": "bda3ee60-8f9a-41b2-a8a2-894aed3b3bed"
       }
-    }
+    },
+    "uuid": "d0443e32-2ffe-4511-96a9-074ac27018dd"
   },
   "menu-item-top-to-disclosure-icon-extra-large": {
     "component": "menu",
@@ -2405,7 +2559,8 @@
         "value": "22px",
         "uuid": "77e97b70-ef7e-4228-8d91-0ff9d9d2b063"
       }
-    }
+    },
+    "uuid": "ef0132be-8760-4217-a056-13bff34a217a"
   },
   "menu-item-top-to-selected-icon-small": {
     "component": "menu",
@@ -2421,7 +2576,8 @@
         "value": "9px",
         "uuid": "943a0b43-6c91-40a3-a680-318a934bf6ef"
       }
-    }
+    },
+    "uuid": "5c019740-3fac-48b6-975b-bdb91b9149ee"
   },
   "menu-item-top-to-selected-icon-medium": {
     "component": "menu",
@@ -2437,7 +2593,8 @@
         "value": "13px",
         "uuid": "61e906e3-6daa-4841-b4f0-54939157a50b"
       }
-    }
+    },
+    "uuid": "3413b81e-4352-4d15-9c62-bd55d2b9c032"
   },
   "menu-item-top-to-selected-icon-large": {
     "component": "menu",
@@ -2453,7 +2610,8 @@
         "value": "17px",
         "uuid": "f84569c5-bb63-4eb1-8193-1130e88e7e5b"
       }
-    }
+    },
+    "uuid": "113a8249-01fd-4395-a8a4-e26eec604a51"
   },
   "menu-item-top-to-selected-icon-extra-large": {
     "component": "menu",
@@ -2469,7 +2627,8 @@
         "value": "22px",
         "uuid": "3ff6cb7a-20cb-4b25-a367-7e4497d0f237"
       }
-    }
+    },
+    "uuid": "2fb80685-2b2b-4656-a01f-92eb5dcb5b24"
   },
   "menu-item-section-divider-height": {
     "component": "menu",
@@ -2493,7 +2652,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "c3844fed-2f84-46da-9b00-cc8e0dbf0336"
       }
-    }
+    },
+    "uuid": "538acb74-223d-4090-8be8-7a7e62a8c765"
   },
   "slider-control-height-small": {
     "component": "slider",
@@ -2514,7 +2674,8 @@
             "value": "18px",
             "uuid": "19adc707-4fc6-40f0-a972-340d6c935908"
           }
-        }
+        },
+        "uuid": "34a35af2-168f-4ec6-bd8c-670606bd9e42"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2533,9 +2694,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "6ea5501c-63cc-45ff-8fa0-5863f1214f5f"
           }
-        }
+        },
+        "uuid": "f4ccceb8-cc36-40e2-bc01-8cde7a3ab403"
       }
-    }
+    },
+    "uuid": "284da01e-1446-4871-b4c5-8afe4dd9ae0c"
   },
   "slider-control-height-medium": {
     "component": "slider",
@@ -2556,7 +2719,8 @@
             "value": "20px",
             "uuid": "7306fc00-67fd-4ccd-aec3-7a14e092da5e"
           }
-        }
+        },
+        "uuid": "6b162e9a-3ef9-4144-b9b8-7b7c4d0e7199"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2575,9 +2739,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "bb501252-cfd3-4ccc-89bf-0aa74713feab"
           }
-        }
+        },
+        "uuid": "dc8f5e85-3a6b-4544-af77-971f5b9fdb1c"
       }
-    }
+    },
+    "uuid": "b5973dd8-236e-4dd3-a4bc-0fd75573e97a"
   },
   "slider-control-height-large": {
     "component": "slider",
@@ -2598,7 +2764,8 @@
             "value": "22px",
             "uuid": "0926d8f3-bdd6-4dde-89d0-6d5d7ab9f094"
           }
-        }
+        },
+        "uuid": "ec657acf-1b0b-43dd-882c-ef0f6e2d52e7"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2617,9 +2784,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "b77e83d6-1a06-42fd-8cb5-e4f68f8c030b"
           }
-        }
+        },
+        "uuid": "a84adc5e-eb51-42e6-bb1b-5a30321abbbd"
       }
-    }
+    },
+    "uuid": "4f382639-8193-4534-bb11-7cafe5123a97"
   },
   "slider-control-height-extra-large": {
     "component": "slider",
@@ -2640,7 +2809,8 @@
             "value": "26px",
             "uuid": "c5d47ebf-c83f-43c3-b2f2-f4d51c40960b"
           }
-        }
+        },
+        "uuid": "bb113fb6-640c-4722-971a-aebc906ab8a6"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2659,9 +2829,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "a5cc511d-b8c4-4fb8-9ca6-cf73c5071324"
           }
-        }
+        },
+        "uuid": "9341150a-f253-4c6e-9c8d-be8b36f402be"
       }
-    }
+    },
+    "uuid": "892b602e-15e7-4074-83b0-5d6fae06bf81"
   },
   "slider-handle-size-small": {
     "component": "slider",
@@ -2680,7 +2852,8 @@
             "value": "18px",
             "uuid": "7feb3d57-59fb-4095-966e-e8ca0e91442f"
           }
-        }
+        },
+        "uuid": "905e59c4-b869-4402-9e2e-f2074ab20da1"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2699,9 +2872,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "f424a2ec-ed1f-4739-b619-494e36f880e7"
           }
-        }
+        },
+        "uuid": "8e355710-0035-48e8-bdd7-a13825f55d81"
       }
-    }
+    },
+    "uuid": "0d2dfe7b-454d-46dc-8a3f-2c2f5c0db5c4"
   },
   "slider-handle-size-medium": {
     "component": "slider",
@@ -2720,7 +2895,8 @@
             "value": "20px",
             "uuid": "278fc618-f6c1-4d30-bf85-075654079003"
           }
-        }
+        },
+        "uuid": "0f08fea5-7d53-4926-993e-802718fef278"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2739,9 +2915,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "04bef018-e59f-4c3d-8ece-79b9614fd813"
           }
-        }
+        },
+        "uuid": "31039254-52a5-4425-97f5-e1f9c6af489f"
       }
-    }
+    },
+    "uuid": "90b773f7-c468-4c4c-8550-348418ecf242"
   },
   "slider-handle-size-large": {
     "component": "slider",
@@ -2760,7 +2938,8 @@
             "value": "22px",
             "uuid": "2a3fb9b0-d701-4e86-8180-9d81f68e91d5"
           }
-        }
+        },
+        "uuid": "06816d82-ca8a-4fe6-a8fe-6d72e22d0454"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2779,9 +2958,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "1d5c2e61-9381-4434-b76f-2160e933ba79"
           }
-        }
+        },
+        "uuid": "b2c009ab-f8e9-4130-a320-6ec09d1367d7"
       }
-    }
+    },
+    "uuid": "787fd218-8574-4fda-9018-4c0e0aea00cb"
   },
   "slider-handle-size-extra-large": {
     "component": "slider",
@@ -2800,7 +2981,8 @@
             "value": "26px",
             "uuid": "413dc697-1f14-47c8-a7f2-e52254513e6e"
           }
-        }
+        },
+        "uuid": "24e9bdd3-8813-4f10-a388-8f184be9ccfd"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2819,9 +3001,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "5edbd2bb-e986-4e3a-a627-04f62c94384f"
           }
-        }
+        },
+        "uuid": "401d401e-5b27-46e8-bcbb-fc047db69e37"
       }
-    }
+    },
+    "uuid": "8b2ace76-b1ea-4531-abec-88125e5fa9de"
   },
   "slider-handle-border-width-down-small": {
     "component": "slider",
@@ -2840,7 +3024,8 @@
             "value": "7px",
             "uuid": "683fb538-290c-423f-990b-d7134e485f51"
           }
-        }
+        },
+        "uuid": "a35fb778-2eaf-4d59-bfbf-5524578cfac5"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2859,9 +3044,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "42c33935-3d84-4aef-a701-082db752cd15"
           }
-        }
+        },
+        "uuid": "2308b8d4-1452-465e-b066-dddddba49d84"
       }
-    }
+    },
+    "uuid": "b8cc4125-f3f5-4aed-ac77-fa188656eeea"
   },
   "slider-handle-border-width-down-medium": {
     "component": "slider",
@@ -2880,7 +3067,8 @@
             "value": "8px",
             "uuid": "25959ff8-6c2f-4612-8d69-b95bfe485ce4"
           }
-        }
+        },
+        "uuid": "385352b1-950f-4504-b379-0078d9fcffc0"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2899,9 +3087,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "9ae32e64-309f-4732-b01b-3bebfb77d286"
           }
-        }
+        },
+        "uuid": "c41ea955-7214-4fe2-98a2-bddab9726bf4"
       }
-    }
+    },
+    "uuid": "a405fec1-85f5-4cfe-b066-b2c716a29285"
   },
   "slider-handle-border-width-down-large": {
     "component": "slider",
@@ -2920,7 +3110,8 @@
             "value": "9px",
             "uuid": "3bf8805b-b4f7-4d0d-af85-d227d6380539"
           }
-        }
+        },
+        "uuid": "873d633e-05b4-41ef-bb03-2ea881a177e2"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2939,9 +3130,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "b8c147c1-f528-4878-bd5f-7438cac59070"
           }
-        }
+        },
+        "uuid": "3cad035f-1b64-4d46-aecb-3ce12187c33c"
       }
-    }
+    },
+    "uuid": "e6c7529c-75a0-4c62-9d46-39af7351bdf3"
   },
   "slider-handle-border-width-down-extra-large": {
     "component": "slider",
@@ -2960,7 +3153,8 @@
             "value": "11px",
             "uuid": "feac9f02-b52a-4694-a5d4-4b1930ab4f07"
           }
-        }
+        },
+        "uuid": "c739756b-8b92-4069-97a7-ad2cedee1627"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2979,9 +3173,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "4e420f10-cf3a-478f-a355-8f4050ea1b06"
           }
-        }
+        },
+        "uuid": "7667b831-1b40-48af-a2f1-3e5be2f529c1"
       }
-    }
+    },
+    "uuid": "fb430d9a-23b5-4e93-9657-29602f65a3d0"
   },
   "slider-handle-gap": {
     "component": "slider",
@@ -2999,7 +3195,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "f7aa286c-54d8-4e6b-98b6-46cf06566ea7"
       }
-    }
+    },
+    "uuid": "5b61baab-5888-4690-9577-5829bc92a839"
   },
   "slider-bottom-to-handle-small": {
     "component": "slider",
@@ -3020,7 +3217,8 @@
             "value": "6px",
             "uuid": "3b96ab4f-6628-4ebd-aba8-2837fce04709"
           }
-        }
+        },
+        "uuid": "4d3c4943-ad01-43e8-9912-836c0cd62cb4"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -3039,9 +3237,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "c9e4aabc-3302-42ae-b794-9d8a46f4ba2e"
           }
-        }
+        },
+        "uuid": "a97ab3cb-c006-4d20-a281-7f3e4b4129f6"
       }
-    }
+    },
+    "uuid": "12b541ed-8b69-47b6-9a46-cb0ca859b7ce"
   },
   "slider-bottom-to-handle-medium": {
     "component": "slider",
@@ -3062,7 +3262,8 @@
             "value": "10px",
             "uuid": "5030babb-0017-4784-84ad-d3aaacf6fa05"
           }
-        }
+        },
+        "uuid": "a521e1e9-2b83-47ff-80da-b5dcdca63545"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -3081,9 +3282,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "5782a8d7-5af0-462f-8f97-0d82344586dd"
           }
-        }
+        },
+        "uuid": "68725fc5-9c62-4922-a32b-c205dc92db36"
       }
-    }
+    },
+    "uuid": "8396f238-4473-4fe9-b66d-0dcedf8f72e1"
   },
   "slider-bottom-to-handle-large": {
     "component": "slider",
@@ -3104,7 +3307,8 @@
             "value": "14px",
             "uuid": "3915ff73-11dd-4389-8d81-2f540ab060f4"
           }
-        }
+        },
+        "uuid": "1b5b9b42-0741-44c1-92ef-5c16b900a880"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -3123,9 +3327,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "4a3a1b22-5ec2-4b1a-9bbe-784e865c5aba"
           }
-        }
+        },
+        "uuid": "d4204626-2c72-477e-9489-bd593522a036"
       }
-    }
+    },
+    "uuid": "c854cfe1-5246-49c6-9bc0-75dbc44a90b6"
   },
   "slider-bottom-to-handle-extra-large": {
     "component": "slider",
@@ -3146,7 +3352,8 @@
             "value": "17px",
             "uuid": "e04d9975-4a54-416b-b5fa-87f3ae930204"
           }
-        }
+        },
+        "uuid": "3d7cd2e0-0255-4c64-9c8c-3f7b556546a5"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -3165,9 +3372,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "fe46f911-0efe-4dfe-b12d-e16fa2939e7f"
           }
-        }
+        },
+        "uuid": "9b8fddb0-d603-493a-a783-88b681d7d7dd"
       }
-    }
+    },
+    "uuid": "087a5833-471d-4548-b869-cd12b516bdc6"
   },
   "slider-control-to-field-label-small": {
     "component": "slider",
@@ -3183,7 +3392,8 @@
         "value": "6px",
         "uuid": "d20768dd-dbf4-48a9-8cc8-3370fa6ef810"
       }
-    }
+    },
+    "uuid": "06f79925-1918-4606-a51c-2b72f492a074"
   },
   "slider-control-to-field-label-medium": {
     "component": "slider",
@@ -3199,7 +3409,8 @@
         "value": "10px",
         "uuid": "20a8d579-038e-4432-b271-8e44b83a9aa1"
       }
-    }
+    },
+    "uuid": "9ceeb406-afeb-49e9-9164-002c9453fc34"
   },
   "slider-control-to-field-label-large": {
     "component": "slider",
@@ -3215,7 +3426,8 @@
         "value": "14px",
         "uuid": "f4fc7ec7-cc02-4ff4-bd9a-f05f9bd59c1d"
       }
-    }
+    },
+    "uuid": "d181e55a-0c31-44bf-9a7e-24c37f5e387c"
   },
   "slider-control-to-field-label-extra-large": {
     "component": "slider",
@@ -3231,7 +3443,8 @@
         "value": "17px",
         "uuid": "9be47810-7a07-4885-a86d-647f5f36d7e5"
       }
-    }
+    },
+    "uuid": "d639f201-40b0-48ab-bafa-9a7747286a6e"
   },
   "picker-minimum-width-multiplier": {
     "component": "picker",
@@ -3253,7 +3466,8 @@
         "value": "9px",
         "uuid": "269725c9-3462-4132-8487-95dd61814448"
       }
-    }
+    },
+    "uuid": "f09fc872-12e3-4c51-886a-5fcc5d37d7c4"
   },
   "picker-visual-to-disclosure-icon-medium": {
     "component": "picker",
@@ -3269,7 +3483,8 @@
         "value": "10px",
         "uuid": "c620ab2b-256d-409a-a80c-7d7c2295efc8"
       }
-    }
+    },
+    "uuid": "8fd9c553-476d-4e22-abd6-998c187adfad"
   },
   "picker-visual-to-disclosure-icon-large": {
     "component": "picker",
@@ -3285,7 +3500,8 @@
         "value": "11px",
         "uuid": "47f5a27f-4039-4668-bb21-aafb9dcb82fb"
       }
-    }
+    },
+    "uuid": "1666090c-68db-472c-b241-1613de626cb7"
   },
   "picker-visual-to-disclosure-icon-extra-large": {
     "component": "picker",
@@ -3301,7 +3517,8 @@
         "value": "13px",
         "uuid": "0ac097c8-020e-4a7b-b692-59dfdf07e3f8"
       }
-    }
+    },
+    "uuid": "9c18fc60-c69e-4432-9229-ed98c69445ca"
   },
   "picker-border-width": {
     "component": "picker",
@@ -3317,7 +3534,8 @@
         "value": "0",
         "uuid": "45392d0b-b92e-4e60-8b82-4bcfef7877eb"
       }
-    }
+    },
+    "uuid": "3eff4ac7-9246-42c7-a49a-b7fe961b13d1"
   },
   "picker-end-edge-to-disclousure-icon-quiet": {
     "component": "picker",
@@ -3353,7 +3571,8 @@
         "value": "140px",
         "uuid": "c89bcff3-23ce-405c-a776-3ece7a2ac342"
       }
-    }
+    },
+    "uuid": "2c9da183-d751-4fb4-8540-79056530396f"
   },
   "text-area-minimum-height": {
     "component": "text-area",
@@ -3369,7 +3588,8 @@
         "value": "70px",
         "uuid": "cb7270a7-8075-435c-81a5-469ef43860c0"
       }
-    }
+    },
+    "uuid": "68e71997-0765-4b0f-ba7a-a0b8f4cc897c"
   },
   "combo-box-minimum-width-multiplier": {
     "component": "combo-box",
@@ -3397,7 +3617,8 @@
         "value": "9px",
         "uuid": "4ccba158-da29-43a1-bbba-6531ecf98807"
       }
-    }
+    },
+    "uuid": "3c0b4b94-a765-4dd3-a2df-c72e9d1baa62"
   },
   "combo-box-visual-to-field-button-medium": {
     "component": "combo-box",
@@ -3413,7 +3634,8 @@
         "value": "10px",
         "uuid": "fefb7088-21e0-4cdf-a8a4-af2a6dcc2a1a"
       }
-    }
+    },
+    "uuid": "693dfa94-4a7a-47b3-b623-71471826b09b"
   },
   "combo-box-visual-to-field-button-large": {
     "component": "combo-box",
@@ -3429,7 +3651,8 @@
         "value": "11px",
         "uuid": "1a529788-8b87-4eef-aa07-a4ffb955761c"
       }
-    }
+    },
+    "uuid": "557ad551-fb5f-4b66-a40c-a1abf2fcb34d"
   },
   "combo-box-visual-to-field-button-extra-large": {
     "component": "combo-box",
@@ -3445,7 +3668,8 @@
         "value": "13px",
         "uuid": "50ecd11d-6710-46e9-b1c6-923bb1d9f494"
       }
-    }
+    },
+    "uuid": "c75b058d-ee9f-462e-b03c-64c6f75e85ab"
   },
   "combo-box-visual-to-field-button-quiet": {
     "component": "combo-box",
@@ -3467,7 +3691,8 @@
         "value": "20px",
         "uuid": "7f33676b-63dd-4d16-b7e1-36520ade716d"
       }
-    }
+    },
+    "uuid": "1bb0d68e-2f6d-4c1d-93e2-81f2ef9e12a3"
   },
   "thumbnail-size-75": {
     "component": "thumbnail",
@@ -3483,7 +3708,8 @@
         "value": "22px",
         "uuid": "852fc55b-beb7-428c-bc0c-452abc204de3"
       }
-    }
+    },
+    "uuid": "e9f84d37-cff3-46bb-bc13-5cf963b50dcc"
   },
   "thumbnail-size-100": {
     "component": "thumbnail",
@@ -3499,7 +3725,8 @@
         "value": "26px",
         "uuid": "545604c8-484f-4697-907c-31e2b2cb46d0"
       }
-    }
+    },
+    "uuid": "0763361e-1d9d-4a9b-92af-3dad58f5f98c"
   },
   "thumbnail-size-200": {
     "component": "thumbnail",
@@ -3515,7 +3742,8 @@
         "value": "28px",
         "uuid": "0e548378-9633-49d2-90d8-b40e1ba7c98e"
       }
-    }
+    },
+    "uuid": "6b6551aa-b460-45cd-8608-13a4d8d5cf6b"
   },
   "thumbnail-size-300": {
     "component": "thumbnail",
@@ -3531,7 +3759,8 @@
         "value": "32px",
         "uuid": "8f4dd02c-d3eb-4654-aea4-b3921048cdbe"
       }
-    }
+    },
+    "uuid": "844d91a7-258f-447d-b0d6-a6f3920896fc"
   },
   "thumbnail-size-400": {
     "component": "thumbnail",
@@ -3547,7 +3776,8 @@
         "value": "36px",
         "uuid": "b0351cf7-f0df-4044-ab26-5b6649ea2e1f"
       }
-    }
+    },
+    "uuid": "d38ca4ff-ec98-421d-98a8-5acc711b91ce"
   },
   "thumbnail-size-500": {
     "component": "thumbnail",
@@ -3563,7 +3793,8 @@
         "value": "40px",
         "uuid": "1798b58e-fce4-411d-ba8d-75006fa4f53e"
       }
-    }
+    },
+    "uuid": "193ad02b-a5f6-4bd3-8513-0d2016d4a1ed"
   },
   "thumbnail-size-600": {
     "component": "thumbnail",
@@ -3579,7 +3810,8 @@
         "value": "46px",
         "uuid": "543dcd25-42cc-4198-b4ba-ba5524b08691"
       }
-    }
+    },
+    "uuid": "36850f43-0dcc-47f6-aa02-0f20a372d294"
   },
   "thumbnail-size-700": {
     "component": "thumbnail",
@@ -3595,7 +3827,8 @@
         "value": "50px",
         "uuid": "5eab16f9-5537-4a14-958d-d96200c5723f"
       }
-    }
+    },
+    "uuid": "ab8e832e-7740-40c3-b204-ac3024fc0b90"
   },
   "thumbnail-size-800": {
     "component": "thumbnail",
@@ -3611,7 +3844,8 @@
         "value": "55px",
         "uuid": "94ca9817-988a-4e4f-9163-954d29204049"
       }
-    }
+    },
+    "uuid": "a038ef04-cda6-4e10-a1f4-50011413fb2e"
   },
   "thumbnail-size-900": {
     "component": "thumbnail",
@@ -3627,7 +3861,8 @@
         "value": "62px",
         "uuid": "97f11dd2-0173-464c-9eef-c260c9e8cf22"
       }
-    }
+    },
+    "uuid": "e72babfa-ddff-44b0-aaa6-19ee756e1759"
   },
   "thumbnail-size-1000": {
     "component": "thumbnail",
@@ -3643,7 +3878,8 @@
         "value": "70px",
         "uuid": "cfbf3ec4-f51d-4a50-b81c-765fff84ce14"
       }
-    }
+    },
+    "uuid": "9225b7e7-e866-4e54-abf0-77ded58b2f25"
   },
   "alert-dialog-minimum-width": {
     "component": "alert-dialog",
@@ -3671,7 +3907,8 @@
         "value": "{heading-size-xs}",
         "uuid": "3f362b57-09eb-4147-b366-5c1f04c9a29f"
       }
-    }
+    },
+    "uuid": "b1341b98-d28d-480d-aa8b-78a7c849ea88"
   },
   "alert-dialog-description-size": {
     "component": "alert-dialog",
@@ -3687,7 +3924,8 @@
         "value": "{body-size-xs}",
         "uuid": "43c5762a-d3a6-49db-9e5e-4a524604fecc"
       }
-    }
+    },
+    "uuid": "aa9edd54-4fb1-457f-b933-c8317314ceee"
   },
   "opacity-checkerboard-square-size": {
     "component": "opacity-checkerboard",
@@ -3703,7 +3941,8 @@
         "value": "10px",
         "uuid": "879360e9-a7b0-47e0-bc4a-931a12877014"
       }
-    }
+    },
+    "uuid": "df681295-c2f5-4d07-a8b0-689a94bb289c"
   },
   "contextual-help-minimum-width": {
     "component": "contextual-help",
@@ -3725,7 +3964,8 @@
         "value": "{heading-size-xxs}",
         "uuid": "e91709ce-79e3-4a81-88fa-e124960d4389"
       }
-    }
+    },
+    "uuid": "4735b809-1359-482f-8af1-cd21ea34454a"
   },
   "contextual-help-body-size": {
     "component": "contextual-help",
@@ -3741,7 +3981,8 @@
         "value": "{body-size-xs}",
         "uuid": "c180fa75-254e-4ee1-8b79-31a3d90254cc"
       }
-    }
+    },
+    "uuid": "54ce0fa1-c891-4bdc-9e20-52b97993dbbc"
   },
   "breadcrumbs-height": {
     "component": "breadcrumbs",
@@ -3769,7 +4010,8 @@
         "value": "84px",
         "uuid": "5e7426da-1a1e-4d37-8c96-4fdac06bfad5"
       }
-    }
+    },
+    "uuid": "ffd9914f-c51c-41ac-b1fb-b0c2ed3c13b6"
   },
   "breadcrumbs-top-to-text": {
     "component": "breadcrumbs",
@@ -3785,7 +4027,8 @@
         "value": "17px",
         "uuid": "c4e58bb6-dcd7-4b64-b881-5b918c346989"
       }
-    }
+    },
+    "uuid": "1a279535-7113-462a-86fe-d2bdd058b48f"
   },
   "breadcrumbs-top-to-text-compact": {
     "component": "breadcrumbs",
@@ -3801,7 +4044,8 @@
         "value": "16px",
         "uuid": "da5c0b1f-a8df-407c-888f-ac62d1fefa7c"
       }
-    }
+    },
+    "uuid": "b5f8e8af-620d-4cfe-87ec-d6d21f776461"
   },
   "breadcrumbs-top-to-text-multiline": {
     "component": "breadcrumbs",
@@ -3817,7 +4061,8 @@
         "value": "15px",
         "uuid": "ea82fc23-82e7-4116-a8bb-186a253675ad"
       }
-    }
+    },
+    "uuid": "72d458f9-f98f-4e96-a190-bbe8c9461e23"
   },
   "breadcrumbs-bottom-to-text": {
     "component": "breadcrumbs",
@@ -3833,7 +4078,8 @@
         "value": "19px",
         "uuid": "971f1589-f80b-4c1e-8814-b5c286c5f561"
       }
-    }
+    },
+    "uuid": "9377b9d1-922c-40c9-8018-4cc528b6e778"
   },
   "breadcrumbs-bottom-to-text-compact": {
     "component": "breadcrumbs",
@@ -3849,7 +4095,8 @@
         "value": "19px",
         "uuid": "d783bd6f-fc7a-4be4-b53a-b8be86018b7b"
       }
-    }
+    },
+    "uuid": "47b9651f-69a7-46af-ae94-196f62a61d1b"
   },
   "breadcrumbs-bottom-to-text-multiline": {
     "component": "breadcrumbs",
@@ -3865,7 +4112,8 @@
         "value": "10px",
         "uuid": "a51a1142-e38e-4055-bd45-ad2bd0045880"
       }
-    }
+    },
+    "uuid": "09bf854f-452b-4494-9c5c-624398030d4d"
   },
   "breadcrumbs-start-edge-to-text": {
     "component": "breadcrumbs",
@@ -3881,7 +4129,8 @@
         "value": "9px",
         "uuid": "6d632147-5a1e-4a19-9fca-019b234d0455"
       }
-    }
+    },
+    "uuid": "844de981-645a-4f24-bab6-6561b762f3c8"
   },
   "breadcrumbs-end-edge-to-text": {
     "component": "breadcrumbs",
@@ -3903,7 +4152,8 @@
         "value": "11px",
         "uuid": "b93aad22-aff0-46d5-b54e-17891f02124a"
       }
-    }
+    },
+    "uuid": "0c3dc1de-a246-44b4-9bb6-650e6542f110"
   },
   "breadcrumbs-top-to-separator-icon": {
     "component": "breadcrumbs",
@@ -3919,7 +4169,8 @@
         "value": "25px",
         "uuid": "882046d8-7111-4020-bf31-b8eb9d9013e0"
       }
-    }
+    },
+    "uuid": "dd645f4d-18c9-41e9-bdd7-7a63cd40728f"
   },
   "breadcrumbs-top-to-separator-icon-compact": {
     "component": "breadcrumbs",
@@ -3935,7 +4186,8 @@
         "value": "23px",
         "uuid": "f6c5b011-ec25-42ea-a708-d7dca1b5fb5a"
       }
-    }
+    },
+    "uuid": "6df1c933-7265-4a4f-bcff-93f0e12871f7"
   },
   "breadcrumbs-top-to-separator-icon-multiline": {
     "component": "breadcrumbs",
@@ -3951,7 +4203,8 @@
         "value": "20px",
         "uuid": "eb3b2566-6fc1-4a2c-a8cf-e40af3d34715"
       }
-    }
+    },
+    "uuid": "eb8f020c-8e62-42ee-9e0d-2de3377385cb"
   },
   "breadcrumbs-separator-icon-to-bottom-text-multiline": {
     "component": "breadcrumbs",
@@ -3967,7 +4220,8 @@
         "value": "15px",
         "uuid": "571239ce-690f-49ee-9e71-d14bbfe4b279"
       }
-    }
+    },
+    "uuid": "442d74d2-69d2-47bd-b474-5e63c8844122"
   },
   "breadcrumbs-truncated-menu-to-separator-icon": {
     "component": "breadcrumbs",
@@ -3989,7 +4243,8 @@
         "value": "10px",
         "uuid": "793da276-18a6-46d0-a0e5-a1676c4df583"
       }
-    }
+    },
+    "uuid": "c39a7d2e-ded0-481a-8b9f-78aa4e1e0e76"
   },
   "breadcrumbs-top-to-truncated-menu-compact": {
     "component": "breadcrumbs",
@@ -4005,7 +4260,8 @@
         "value": "5px",
         "uuid": "d5e92b0a-6d37-4b77-a5d0-6c4f1b9a722c"
       }
-    }
+    },
+    "uuid": "6f36fa37-f5f5-49fe-9b06-e69e51a1fb46"
   },
   "breadcrumbs-start-edge-to-truncated-menu": {
     "component": "breadcrumbs",
@@ -4033,7 +4289,8 @@
         "value": "20px",
         "uuid": "6f6fae3d-eafd-41d7-a863-b2f0b57240ab"
       }
-    }
+    },
+    "uuid": "74b61508-450d-4ccf-a004-87c6fdee3d14"
   },
   "avatar-size-75": {
     "component": "avatar",
@@ -4049,7 +4306,8 @@
         "value": "22px",
         "uuid": "f23636e9-93e2-444d-a95b-1311a7e074f3"
       }
-    }
+    },
+    "uuid": "fd0f42d3-3d6e-4078-9e7d-54cdf68779de"
   },
   "avatar-size-100": {
     "component": "avatar",
@@ -4065,7 +4323,8 @@
         "value": "26px",
         "uuid": "a2833b95-ba74-4caf-89e6-8294465d2780"
       }
-    }
+    },
+    "uuid": "36128b0d-b39f-49b0-9326-9aabdd9d4a18"
   },
   "avatar-size-200": {
     "component": "avatar",
@@ -4081,7 +4340,8 @@
         "value": "28px",
         "uuid": "7bfa97a1-39a8-4a30-af13-31ce1393098a"
       }
-    }
+    },
+    "uuid": "e799a14e-ebe3-4a79-bffe-02519e4f8283"
   },
   "avatar-size-300": {
     "component": "avatar",
@@ -4097,7 +4357,8 @@
         "value": "32px",
         "uuid": "b0bd14f7-9642-4e20-90c4-68f38a53e72c"
       }
-    }
+    },
+    "uuid": "9882a002-e081-4537-b31e-30d8d90a77b3"
   },
   "avatar-size-400": {
     "component": "avatar",
@@ -4113,7 +4374,8 @@
         "value": "36px",
         "uuid": "44237baf-1128-445d-8337-a943c6ac0019"
       }
-    }
+    },
+    "uuid": "7dd556a4-252f-4b83-93cc-827da0551b3a"
   },
   "avatar-size-500": {
     "component": "avatar",
@@ -4129,7 +4391,8 @@
         "value": "40px",
         "uuid": "db33d97e-15e4-4248-a8cf-4b69d745a2e0"
       }
-    }
+    },
+    "uuid": "a49b2760-8820-4266-bdb9-fc76ddc6d738"
   },
   "avatar-size-600": {
     "component": "avatar",
@@ -4145,7 +4408,8 @@
         "value": "46px",
         "uuid": "9ea7c014-2c8d-403f-ad7f-fa3c08a3a46d"
       }
-    }
+    },
+    "uuid": "1f23f3a9-5b76-4d27-a934-dcf8dda0afef"
   },
   "avatar-size-700": {
     "component": "avatar",
@@ -4161,7 +4425,8 @@
         "value": "50px",
         "uuid": "0bec4f0f-efb2-44f9-a131-28f8fe248c40"
       }
-    }
+    },
+    "uuid": "a73d1b8d-745c-4ad6-986f-e28c8937285a"
   },
   "alert-banner-minimum-height": {
     "component": "alert-banner",
@@ -4177,7 +4442,8 @@
         "value": "64px",
         "uuid": "6d313800-3020-45f8-969d-63e81057ff97"
       }
-    }
+    },
+    "uuid": "63ee45bd-4e77-4ab6-b0ff-8466a4072f52"
   },
   "alert-banner-width": {
     "component": "alert-banner",
@@ -4193,7 +4459,8 @@
         "value": "680px",
         "uuid": "b02e6302-d443-4b94-bda9-f4cc90b3d4ca"
       }
-    }
+    },
+    "uuid": "11184272-5c12-4487-b3db-f784466d0c58"
   },
   "alert-banner-to-top-workflow-icon": {
     "component": "alert-banner",
@@ -4217,7 +4484,8 @@
         "value": "21px",
         "uuid": "402c755b-322c-4ea0-856c-ca209bdaa8ec"
       }
-    }
+    },
+    "uuid": "6e8a1f16-b7f2-4bbc-8ce8-9f2badebb500"
   },
   "alert-banner-to-top-text": {
     "component": "alert-banner",
@@ -4241,7 +4509,8 @@
         "value": "21px",
         "uuid": "8db02117-b543-4b3e-b0ff-203e9a821708"
       }
-    }
+    },
+    "uuid": "c586013e-3ba7-4e91-9377-decb2e82e3c6"
   },
   "alert-banner-to-bottom-text": {
     "component": "alert-banner",
@@ -4265,7 +4534,8 @@
         "value": "22px",
         "uuid": "5f2b2bc1-ebb0-46dd-a563-58df6307996d"
       }
-    }
+    },
+    "uuid": "31c44c54-bb66-41f2-b47f-594931457cad"
   },
   "rating-indicator-width": {
     "component": "rating",
@@ -4281,7 +4551,8 @@
         "value": "22px",
         "uuid": "dce9ff1e-06d1-49a5-817f-5319f4ab15e2"
       }
-    }
+    },
+    "uuid": "7c4bf44d-6562-467c-9bec-a24243c8028e"
   },
   "rating-indicator-to-icon": {
     "component": "rating",
@@ -4297,7 +4568,8 @@
         "value": "5px",
         "uuid": "8e13ea1d-8000-485e-8700-5522cc71b95c"
       }
-    }
+    },
+    "uuid": "fed766b6-a8e3-42d5-82f5-fb3fa0fc229c"
   },
   "color-area-width": {
     "component": "color-area",
@@ -4313,7 +4585,8 @@
         "value": "240px",
         "uuid": "e5daae6b-7040-4e80-a251-db4c8c79e113"
       }
-    }
+    },
+    "uuid": "f6071bbd-61a1-46d8-9591-4da270732828"
   },
   "color-area-minimum-width": {
     "component": "color-area",
@@ -4329,7 +4602,8 @@
         "value": "80px",
         "uuid": "126cd0b8-55cc-489c-9582-fddde76b431c"
       }
-    }
+    },
+    "uuid": "5e72964b-31cc-44f7-9535-d6cf5a4f5131"
   },
   "color-area-height": {
     "component": "color-area",
@@ -4345,7 +4619,8 @@
         "value": "240px",
         "uuid": "552a014a-c590-48f8-98dc-26849b62c3ab"
       }
-    }
+    },
+    "uuid": "51fc2f80-5e26-4b16-9f99-bd7cdebe120e"
   },
   "color-area-minimum-height": {
     "component": "color-area",
@@ -4361,7 +4636,8 @@
         "value": "80px",
         "uuid": "9b84d54e-2b10-4502-b072-ded2a8bf9cb3"
       }
-    }
+    },
+    "uuid": "09eba209-c3f1-4ed6-96cc-47c63c4b0668"
   },
   "color-area-border-width": {
     "component": "color-area",
@@ -4389,7 +4665,8 @@
         "value": "240px",
         "uuid": "81d866f0-e2a6-4f27-bb22-6675cce4e937"
       }
-    }
+    },
+    "uuid": "441c23c9-98af-4db0-a74e-dbc70d34a0c4"
   },
   "color-wheel-minimum-width": {
     "component": "color-wheel",
@@ -4405,7 +4682,8 @@
         "value": "219px",
         "uuid": "6733cd28-a949-40f7-bd36-034af9c0261f"
       }
-    }
+    },
+    "uuid": "675789ec-f6bc-4378-a1fa-94e031de52f7"
   },
   "color-wheel-color-area-margin": {
     "component": "color-wheel",
@@ -4427,7 +4705,8 @@
         "value": "240px",
         "uuid": "c42de1ce-088a-4918-a7dc-36507c8acedf"
       }
-    }
+    },
+    "uuid": "f2c2cd54-9bc9-4eb9-b903-ebd285be2101"
   },
   "color-slider-minimum-length": {
     "component": "color-slider",
@@ -4443,7 +4722,8 @@
         "value": "100px",
         "uuid": "120308f7-4220-420e-b836-20176a8184b7"
       }
-    }
+    },
+    "uuid": "56a81108-825a-4b29-bc9a-af66d23c2a9a"
   },
   "color-slider-border-width": {
     "component": "color-slider",
@@ -4489,7 +4769,8 @@
         "value": "{heading-size-s}",
         "uuid": "cfca5a29-7073-4627-8a61-27d37552dc03"
       }
-    }
+    },
+    "uuid": "ef4d00df-ab62-4206-b101-728419d8eb8f"
   },
   "illustrated-message-cjk-title-size": {
     "component": "illustrated-message",
@@ -4505,7 +4786,8 @@
         "value": "{heading-cjk-size-s}",
         "uuid": "00c938e6-e62e-4bc3-8884-cf23b10e286c"
       }
-    }
+    },
+    "uuid": "d241cc79-d102-4732-afe2-fec515ba1d18"
   },
   "illustrated-message-body-size": {
     "component": "illustrated-message",
@@ -4521,7 +4803,8 @@
         "value": "{body-size-xs}",
         "uuid": "f3ba73a4-16ba-44a4-abf2-9893e8f02344"
       }
-    }
+    },
+    "uuid": "fed462be-2f98-4dcf-9822-53f7321a305d"
   },
   "search-field-minimum-width-multiplier": {
     "component": "search-field",
@@ -4645,7 +4928,8 @@
         "value": "216px",
         "uuid": "b3f14387-44fd-43d3-a152-c8e691ef87df"
       }
-    }
+    },
+    "uuid": "b8c6b0f5-b498-46e3-8fed-b026af86482a"
   },
   "coach-mark-minimum-width": {
     "component": "coach-mark",
@@ -4661,7 +4945,8 @@
         "value": "216px",
         "uuid": "9004d69e-5726-42f5-a4d0-de09db2de784"
       }
-    }
+    },
+    "uuid": "53ab0df3-12d4-4460-b5a7-234e40c4456a"
   },
   "coach-mark-maximum-width": {
     "component": "coach-mark",
@@ -4677,7 +4962,8 @@
         "value": "248px",
         "uuid": "7f8346b2-f8bf-441d-8412-2a2a28cf4b90"
       }
-    }
+    },
+    "uuid": "a2fbb90f-b481-49bb-aa87-d67b0144c8c5"
   },
   "coach-mark-edge-to-content": {
     "component": "coach-mark",
@@ -4693,7 +4979,8 @@
         "value": "{spacing-300}",
         "uuid": "11fb0ab2-d6a0-4da8-9c83-c1f6b918406a"
       }
-    }
+    },
+    "uuid": "41bda81f-182f-46ce-961b-83db9b5211bd"
   },
   "coach-mark-pagination-text-to-bottom-edge": {
     "component": "coach-mark",
@@ -4709,7 +4996,8 @@
         "value": "22px",
         "uuid": "cd48e6b7-a4d8-4a22-8d65-531d770a9898"
       }
-    }
+    },
+    "uuid": "2e16deca-76be-472d-97ec-13596db8089d"
   },
   "coach-mark-media-height": {
     "component": "coach-mark",
@@ -4725,7 +5013,8 @@
         "value": "162px",
         "uuid": "45b31e46-b878-40a2-a28a-91c480f45253"
       }
-    }
+    },
+    "uuid": "f8ee195f-0b00-41fb-bb76-a22a7f0ccaff"
   },
   "coach-mark-media-minimum-height": {
     "component": "coach-mark",
@@ -4741,7 +5030,8 @@
         "value": "121px",
         "uuid": "53703e12-f837-4573-bd44-e4727ed2aeaa"
       }
-    }
+    },
+    "uuid": "f35ee551-3eab-4650-938d-60b4bb10ec3d"
   },
   "coach-mark-title-size": {
     "component": "coach-mark",
@@ -4757,7 +5047,8 @@
         "value": "{heading-size-xxs}",
         "uuid": "cd4848b6-d560-475a-9d80-f7b5acebce10"
       }
-    }
+    },
+    "uuid": "fe336e37-83d3-4ede-ac92-1e8d2b015415"
   },
   "coach-mark-body-size": {
     "component": "coach-mark",
@@ -4773,7 +5064,8 @@
         "value": "{body-size-xs}",
         "uuid": "a0abef77-dafe-4158-9faa-a4b4b2871e54"
       }
-    }
+    },
+    "uuid": "c7ea57c3-9715-4347-aa19-efdbdd35b7e0"
   },
   "coach-mark-pagination-body-size": {
     "component": "coach-mark",
@@ -4789,7 +5081,8 @@
         "value": "{body-size-xs}",
         "uuid": "350d9235-ff9e-43d7-9298-56b36d58d6de"
       }
-    }
+    },
+    "uuid": "5a9623c0-37f0-4363-87ed-b015e9f73455"
   },
   "accordion-top-to-text-compact-small": {
     "component": "accordion",
@@ -4811,7 +5104,8 @@
         "value": "7px",
         "uuid": "1aa82f7b-64d5-4a5c-921c-4b36d0c4bd2d"
       }
-    }
+    },
+    "uuid": "aad6a2e4-89ed-4b54-89cb-17643f5cf826"
   },
   "accordion-small-top-to-text-spacious": {
     "component": "accordion",
@@ -4831,7 +5125,8 @@
         "deprecated": true,
         "deprecated_comment": "Introduced as an error. Use accordion-top-to-text-spacious-small instead"
       }
-    }
+    },
+    "uuid": "21d37fe2-7897-4071-8f80-9c5ace73c0ea"
   },
   "accordion-top-to-text-compact-medium": {
     "component": "accordion",
@@ -4853,7 +5148,8 @@
         "value": "9px",
         "uuid": "1dab0630-304c-4087-b21c-83cd0e40b1d4"
       }
-    }
+    },
+    "uuid": "f3aaa4f6-a58d-4612-bbfc-0d4647981067"
   },
   "accordion-top-to-text-spacious-medium": {
     "component": "accordion",
@@ -4869,7 +5165,8 @@
         "value": "14px",
         "uuid": "63602a66-5f96-4e6a-8bf0-2ac03321a577"
       }
-    }
+    },
+    "uuid": "666c8b52-bc14-4588-8147-ab11fac0a413"
   },
   "accordion-top-to-text-compact-large": {
     "component": "accordion",
@@ -4885,7 +5182,8 @@
         "value": "7px",
         "uuid": "c09ca9bf-1b8b-4ff3-93b7-e9296472dc76"
       }
-    }
+    },
+    "uuid": "861bb30c-d322-4085-b7b5-8c1d1a3d6b02"
   },
   "accordion-top-to-text-regular-large": {
     "component": "accordion",
@@ -4901,7 +5199,8 @@
         "value": "12px",
         "uuid": "96442c10-e84d-4b26-9b49-534597d3193e"
       }
-    }
+    },
+    "uuid": "48c043d5-24c8-4ac3-9745-6daa65f21a43"
   },
   "accordion-top-to-text-spacious-large": {
     "component": "accordion",
@@ -4917,7 +5216,8 @@
         "value": "14px",
         "uuid": "e90553f0-d71e-44c2-b70a-89110fab7c6a"
       }
-    }
+    },
+    "uuid": "c5e08a35-8c56-4b29-8edc-d8fc64a19b0b"
   },
   "accordion-top-to-text-compact-extra-large": {
     "component": "accordion",
@@ -4933,7 +5233,8 @@
         "value": "7px",
         "uuid": "5ebd5aab-49b3-49d1-be25-8aff15217eda"
       }
-    }
+    },
+    "uuid": "d41f8c32-35e1-49e6-be09-cfd46c2aa064"
   },
   "accordion-top-to-text-regular-extra-large": {
     "component": "accordion",
@@ -4949,7 +5250,8 @@
         "value": "12px",
         "uuid": "51f14c59-3071-45e7-b919-683c30589da9"
       }
-    }
+    },
+    "uuid": "d29f4dc3-b39b-46b6-bcec-64e9019d684f"
   },
   "accordion-top-to-text-spacious-extra-large": {
     "component": "accordion",
@@ -4965,7 +5267,8 @@
         "value": "14px",
         "uuid": "bd300d17-3599-4382-8a7d-1b78700d49e9"
       }
-    }
+    },
+    "uuid": "35dd0fbb-b065-4512-aae0-8705b5ead4ca"
   },
   "accordion-bottom-to-text-compact-small": {
     "component": "accordion",
@@ -4981,7 +5284,8 @@
         "value": "4px",
         "uuid": "af95123b-2ab5-49bb-a070-1ca48b498f58"
       }
-    }
+    },
+    "uuid": "b74e3f61-5d03-4104-a809-ed5b7fe60611"
   },
   "accordion-bottom-to-text-regular-small": {
     "component": "accordion",
@@ -4997,7 +5301,8 @@
         "value": "9px",
         "uuid": "be3de2dc-7c53-4d8c-91b1-6aed5ea0895e"
       }
-    }
+    },
+    "uuid": "46761c4b-8224-48ae-bf79-9672d250e53f"
   },
   "accordion-bottom-to-text-spacious-small": {
     "component": "accordion",
@@ -5013,7 +5318,8 @@
         "value": "14px",
         "uuid": "56a65744-b195-4faf-ab5c-69a8424593f9"
       }
-    }
+    },
+    "uuid": "0f91dd70-a1c7-487b-a9b3-d6a462bf9e57"
   },
   "accordion-bottom-to-text-compact-medium": {
     "component": "accordion",
@@ -5029,7 +5335,8 @@
         "value": "8px",
         "uuid": "97b9278a-11d0-4470-99c3-e2d47ca5a714"
       }
-    }
+    },
+    "uuid": "0cf0f58c-8eea-4a65-8636-4764654d56e8"
   },
   "accordion-bottom-to-text-regular-medium": {
     "component": "accordion",
@@ -5045,7 +5352,8 @@
         "value": "13px",
         "uuid": "6a83235c-7d94-4cb7-9f6b-6dc82fcb2fb0"
       }
-    }
+    },
+    "uuid": "d14a70a4-dd33-4e1d-972e-4d453135f675"
   },
   "accordion-bottom-to-text-spacious-medium": {
     "component": "accordion",
@@ -5061,7 +5369,8 @@
         "value": "18px",
         "uuid": "05d8a39d-a0d5-496c-810a-f1244c31b169"
       }
-    }
+    },
+    "uuid": "b76125b4-5be8-4324-b182-e6dc70e0e4ff"
   },
   "accordion-bottom-to-text-compact-large": {
     "component": "accordion",
@@ -5077,7 +5386,8 @@
         "value": "9px",
         "uuid": "b4f92e98-694f-46cc-91be-8e0e2d5a17a4"
       }
-    }
+    },
+    "uuid": "866479c6-c08a-452b-80db-0eaab1010f4f"
   },
   "accordion-bottom-to-text-regular-large": {
     "component": "accordion",
@@ -5093,7 +5403,8 @@
         "value": "14px",
         "uuid": "c449b115-2116-45bd-8d3d-03fb806dd460"
       }
-    }
+    },
+    "uuid": "0d3624d6-e476-49e0-b382-7c66ee070cb2"
   },
   "accordion-bottom-to-text-spacious-large": {
     "component": "accordion",
@@ -5109,7 +5420,8 @@
         "value": "19px",
         "uuid": "2a6fa386-4eba-44d5-b129-c832264fafd9"
       }
-    }
+    },
+    "uuid": "ed84ee4f-0bee-4a6d-aca8-68836f140f67"
   },
   "accordion-bottom-to-text-compact-extra-large": {
     "component": "accordion",
@@ -5125,7 +5437,8 @@
         "value": "10px",
         "uuid": "70e6d9e7-2a8e-4f0d-96d6-aac7cde829bd"
       }
-    }
+    },
+    "uuid": "695fb872-0b52-4477-942e-780e8418bdfe"
   },
   "accordion-bottom-to-text-regular-extra-large": {
     "component": "accordion",
@@ -5141,7 +5454,8 @@
         "value": "15px",
         "uuid": "ae5feb3e-bb5d-4187-b81f-3a42ebf47e78"
       }
-    }
+    },
+    "uuid": "733a9bbd-9b08-4a03-add2-defa39fbe9b5"
   },
   "accordion-bottom-to-text-spacious-extra-large": {
     "component": "accordion",
@@ -5157,7 +5471,8 @@
         "value": "21px",
         "uuid": "ba11dc6e-fbd8-46bc-94fd-b4d02f654d2d"
       }
-    }
+    },
+    "uuid": "d8d072e2-ffc8-4211-ac06-6f2ada7c1d68"
   },
   "accordion-minimum-width": {
     "component": "accordion",
@@ -5173,7 +5488,8 @@
         "value": "250px",
         "uuid": "ae8169fe-1672-4e95-87a5-344ec4d7f163"
       }
-    }
+    },
+    "uuid": "d2ec2861-21dd-4282-b483-abd69bb8ef71"
   },
   "accordion-disclosure-indicator-to-text": {
     "component": "accordion",
@@ -5213,7 +5529,8 @@
         "value": "10px",
         "uuid": "9c651dee-7d77-414d-930b-7c6b78cfed1b"
       }
-    }
+    },
+    "uuid": "cd059cf7-1eff-4b03-bee5-d254dbd5df30"
   },
   "accordion-content-area-bottom-to-content": {
     "component": "accordion",
@@ -5229,7 +5546,8 @@
         "value": "20px",
         "uuid": "48383ab9-1e66-47f9-988b-6f59b7349241"
       }
-    }
+    },
+    "uuid": "78c5f8c2-6436-4a5d-a67b-c90f2cd8e47b"
   },
   "color-handle-size": {
     "component": "color-handle",
@@ -5245,7 +5563,8 @@
         "value": "20px",
         "uuid": "b81cc6a6-390f-43dc-a6c8-dd335c177da3"
       }
-    }
+    },
+    "uuid": "1cb8d622-071a-417b-ab40-7350f7bce364"
   },
   "color-handle-size-key-focus": {
     "component": "color-handle",
@@ -5261,7 +5580,8 @@
         "value": "40px",
         "uuid": "feddbfb7-7f1a-4eee-9cbf-b393aafb7385"
       }
-    }
+    },
+    "uuid": "f94a7f6f-58d8-4d82-b480-843106cbf828"
   },
   "color-handle-border-width": {
     "component": "color-handle",
@@ -5313,7 +5633,8 @@
         "value": "10px",
         "uuid": "fdc8b7ae-2356-4d49-ba54-0ea471be2986"
       }
-    }
+    },
+    "uuid": "f3ebd248-9c8d-4b9e-b6d0-4104f19a64e9"
   },
   "table-column-header-row-top-to-text-medium": {
     "component": "table",
@@ -5329,7 +5650,8 @@
         "value": "9px",
         "uuid": "ff3c5329-ccec-4b94-b200-29a377b34380"
       }
-    }
+    },
+    "uuid": "d76f977c-bb72-4f01-9b1c-5b02c205a1ff"
   },
   "table-column-header-row-top-to-text-large": {
     "component": "table",
@@ -5345,7 +5667,8 @@
         "value": "13px",
         "uuid": "a02666d8-4ae2-42d2-b48e-419d5070e7ca"
       }
-    }
+    },
+    "uuid": "e15274c0-d45a-4bbb-bf0b-d4e12e85a2b6"
   },
   "table-column-header-row-top-to-text-extra-large": {
     "component": "table",
@@ -5361,7 +5684,8 @@
         "value": "16px",
         "uuid": "265247a7-bbc3-42b8-910d-946e8d04aee2"
       }
-    }
+    },
+    "uuid": "cf6c2df3-bf95-4612-b40b-95a6c963c3b7"
   },
   "table-column-header-row-bottom-to-text-small": {
     "component": "table",
@@ -5377,7 +5701,8 @@
         "value": "11px",
         "uuid": "9cf85eae-ec15-4bb0-ba48-00ec946306a5"
       }
-    }
+    },
+    "uuid": "ecc5e054-dd12-4973-ac05-97ed170b134c"
   },
   "table-column-header-row-bottom-to-text-medium": {
     "component": "table",
@@ -5393,7 +5718,8 @@
         "value": "10px",
         "uuid": "631d14a5-1d2e-4e4a-90e8-146e8a397530"
       }
-    }
+    },
+    "uuid": "c5040d29-5591-4793-847d-0d7123fd1bb8"
   },
   "table-column-header-row-bottom-to-text-large": {
     "component": "table",
@@ -5409,7 +5735,8 @@
         "value": "13px",
         "uuid": "e465ee66-392f-469f-a46c-6c98df03b046"
       }
-    }
+    },
+    "uuid": "cde1eaa9-2146-45fb-b8f6-edfb7ec9cec1"
   },
   "table-column-header-row-bottom-to-text-extra-large": {
     "component": "table",
@@ -5425,7 +5752,8 @@
         "value": "17px",
         "uuid": "c8bd103d-d952-4649-a7a0-09ae5242ea17"
       }
-    }
+    },
+    "uuid": "046321fc-4bc1-4485-94c3-9a674f30f3d1"
   },
   "table-row-height-small-compact": {
     "component": "table",
@@ -5465,7 +5793,8 @@
         "value": "40px",
         "uuid": "cdbb999d-c2a9-4325-9689-bede2ad3559a"
       }
-    }
+    },
+    "uuid": "2fdb0923-5abb-4790-a8b0-0667ac31c21f"
   },
   "table-row-height-medium-regular": {
     "component": "table",
@@ -5481,7 +5810,8 @@
         "value": "50px",
         "uuid": "72e6564c-2acf-4f77-80d9-b21d2d55a580"
       }
-    }
+    },
+    "uuid": "e5b206df-476c-4446-ac7b-33a09d199b4e"
   },
   "table-row-height-large-regular": {
     "component": "table",
@@ -5497,7 +5827,8 @@
         "value": "60px",
         "uuid": "b92bc058-27ea-4e86-a1a2-e5dbae3c2ee8"
       }
-    }
+    },
+    "uuid": "d736c3fc-f065-4bea-a4a1-9ae94542d919"
   },
   "table-row-height-extra-large-regular": {
     "component": "table",
@@ -5513,7 +5844,8 @@
         "value": "70px",
         "uuid": "b7753c9a-8854-4927-89dd-80d47bff5fa5"
       }
-    }
+    },
+    "uuid": "71e3db99-d203-4a8f-afe9-f6d278cd2ddf"
   },
   "table-row-height-small-spacious": {
     "component": "table",
@@ -5529,7 +5861,8 @@
         "value": "50px",
         "uuid": "ab252e1f-a13a-4630-a6ff-0cfa6e6f0c03"
       }
-    }
+    },
+    "uuid": "537269dd-f836-402f-8c13-b2c91788f9b5"
   },
   "table-row-height-medium-spacious": {
     "component": "table",
@@ -5545,7 +5878,8 @@
         "value": "60px",
         "uuid": "572d1c5f-62a1-4bfc-a3e0-520a999545fe"
       }
-    }
+    },
+    "uuid": "910487af-814b-4c43-9f7e-4002ff213aa1"
   },
   "table-row-height-large-spacious": {
     "component": "table",
@@ -5561,7 +5895,8 @@
         "value": "70px",
         "uuid": "e377fd73-62ca-481c-93f6-c62eb35ca720"
       }
-    }
+    },
+    "uuid": "1d741845-48e9-4e5c-b586-a89b8e4bb1f2"
   },
   "table-row-height-extra-large-spacious": {
     "component": "table",
@@ -5577,7 +5912,8 @@
         "value": "80px",
         "uuid": "6efd745f-2a9a-4eea-a0a3-ebe0d3fbc149"
       }
-    }
+    },
+    "uuid": "20d8ac93-5c81-4d55-bab6-aa2fb0d22a21"
   },
   "table-row-top-to-text-small-compact": {
     "component": "table",
@@ -5641,7 +5977,8 @@
         "value": "10px",
         "uuid": "98014297-14dc-4547-944a-8951c7f6f253"
       }
-    }
+    },
+    "uuid": "06fec8c1-0345-4130-befd-723a5cc18a7e"
   },
   "table-row-top-to-text-medium-regular": {
     "component": "table",
@@ -5657,7 +5994,8 @@
         "value": "14px",
         "uuid": "7df1dc32-b96d-41e3-a372-9bcaec7c2ccb"
       }
-    }
+    },
+    "uuid": "d80c3254-92ef-4c3d-ad68-3063a8f904f9"
   },
   "table-row-top-to-text-large-regular": {
     "component": "table",
@@ -5673,7 +6011,8 @@
         "value": "18px",
         "uuid": "0108018e-6146-45c9-b032-e3d44dfb8d84"
       }
-    }
+    },
+    "uuid": "55ffc07c-59e6-467f-90bd-6e891bb4f260"
   },
   "table-row-top-to-text-extra-large-regular": {
     "component": "table",
@@ -5689,7 +6028,8 @@
         "value": "21px",
         "uuid": "c381a3c4-e0a3-4e86-b279-f51ee6e9e532"
       }
-    }
+    },
+    "uuid": "8ff56511-a776-495a-a8ac-41f565afa951"
   },
   "table-row-bottom-to-text-small-regular": {
     "component": "table",
@@ -5705,7 +6045,8 @@
         "value": "11px",
         "uuid": "d3147ee6-dc34-46e2-8379-02d9690ff80a"
       }
-    }
+    },
+    "uuid": "1bb628a1-b1e1-436a-93b7-51627275e82b"
   },
   "table-row-bottom-to-text-medium-regular": {
     "component": "table",
@@ -5721,7 +6062,8 @@
         "value": "15px",
         "uuid": "e80339a8-22c4-4b53-9a4a-a4456f6cab3f"
       }
-    }
+    },
+    "uuid": "67ccae46-0ae7-4992-ad31-23f148d71702"
   },
   "table-row-bottom-to-text-large-regular": {
     "component": "table",
@@ -5737,7 +6079,8 @@
         "value": "18px",
         "uuid": "151bf172-2889-4c98-8f15-5b6cdcb30d4b"
       }
-    }
+    },
+    "uuid": "12859ac5-346f-464a-afe6-626667d92a8e"
   },
   "table-row-bottom-to-text-extra-large-regular": {
     "component": "table",
@@ -5753,7 +6096,8 @@
         "value": "22px",
         "uuid": "c9ac99be-86c3-4f6c-a2a5-3487041bc95e"
       }
-    }
+    },
+    "uuid": "75c1e663-5576-4c04-a9ce-9bfeb8603ee0"
   },
   "table-row-top-to-text-small-spacious": {
     "component": "table",
@@ -5769,7 +6113,8 @@
         "value": "15px",
         "uuid": "625733b1-78b3-4dd0-9636-71d59c14e013"
       }
-    }
+    },
+    "uuid": "cb5025d7-86f5-4608-83b1-2e38774450e0"
   },
   "table-row-top-to-text-medium-spacious": {
     "component": "table",
@@ -5785,7 +6130,8 @@
         "value": "18px",
         "uuid": "cfa36bf7-cce0-4049-970a-8f11c6d60673"
       }
-    }
+    },
+    "uuid": "e82e7cd2-161b-4a82-968a-bc80ad68232f"
   },
   "table-row-top-to-text-large-spacious": {
     "component": "table",
@@ -5801,7 +6147,8 @@
         "value": "23px",
         "uuid": "769d6bbf-64ba-4c08-8a57-580838de1d48"
       }
-    }
+    },
+    "uuid": "5a5e6db9-7fdf-4883-a306-59df7c8fe461"
   },
   "table-row-top-to-text-extra-large-spacious": {
     "component": "table",
@@ -5817,7 +6164,8 @@
         "value": "26px",
         "uuid": "90c39289-3112-49a3-8e65-d112c97f7479"
       }
-    }
+    },
+    "uuid": "5d5fdc5d-125b-40ea-805d-c4e6557c386c"
   },
   "table-row-bottom-to-text-small-spacious": {
     "component": "table",
@@ -5833,7 +6181,8 @@
         "value": "16px",
         "uuid": "07dd5018-1999-4b95-9a59-fe1c2fcc380f"
       }
-    }
+    },
+    "uuid": "ece055b7-1adf-4361-9f45-b4c2fc3ffa7c"
   },
   "table-row-bottom-to-text-medium-spacious": {
     "component": "table",
@@ -5849,7 +6198,8 @@
         "value": "18px",
         "uuid": "8273e28d-20b4-4575-9449-9178af111e38"
       }
-    }
+    },
+    "uuid": "8daea87d-dc45-49c4-a1a4-2b25352b6803"
   },
   "table-row-bottom-to-text-large-spacious": {
     "component": "table",
@@ -5865,7 +6215,8 @@
         "value": "23px",
         "uuid": "4bc11bec-9c86-4a6c-85d1-382c71c1352d"
       }
-    }
+    },
+    "uuid": "6b14dcce-9726-46e0-b524-57031ae5e2ff"
   },
   "table-row-bottom-to-text-extra-large-spacious": {
     "component": "table",
@@ -5881,7 +6232,8 @@
         "value": "27px",
         "uuid": "06ada9fe-ceef-4fb4-88ee-37c2edee5418"
       }
-    }
+    },
+    "uuid": "ad376a29-0880-4248-83ba-6ca7a879d656"
   },
   "table-edge-to-content": {
     "component": "table",
@@ -5909,7 +6261,8 @@
         "value": "30px",
         "uuid": "cb7c89c0-9f31-43c4-8427-2e048f549ff7"
       }
-    }
+    },
+    "uuid": "067aa068-db38-411f-87ad-760dd6dcdb07"
   },
   "table-header-row-checkbox-to-top-small": {
     "component": "table",
@@ -5925,7 +6278,8 @@
         "value": "14px",
         "uuid": "296d445c-243d-454c-9f5a-146c13d0cded"
       }
-    }
+    },
+    "uuid": "54338737-e05a-44dc-a2d6-d6bb83ec8165"
   },
   "table-header-row-checkbox-to-top-medium": {
     "component": "table",
@@ -5941,7 +6295,8 @@
         "value": "13px",
         "uuid": "2e168a2b-46aa-453f-9ca1-746485216c84"
       }
-    }
+    },
+    "uuid": "d9045503-b75d-4a5f-90b5-d3eddd119649"
   },
   "table-header-row-checkbox-to-top-large": {
     "component": "table",
@@ -5957,7 +6312,8 @@
         "value": "17px",
         "uuid": "f6648787-3cf1-4af8-aa4f-15669ea1626d"
       }
-    }
+    },
+    "uuid": "6f957e77-84ea-4e0b-882a-c943cb148bb9"
   },
   "table-header-row-checkbox-to-top-extra-large": {
     "component": "table",
@@ -5973,7 +6329,8 @@
         "value": "21px",
         "uuid": "42a78148-e111-4124-a7a6-d9baa2ca963f"
       }
-    }
+    },
+    "uuid": "fe8df7cb-9796-47fb-ac1c-c98173781049"
   },
   "table-row-checkbox-to-top-small-compact": {
     "component": "table",
@@ -5989,7 +6346,8 @@
         "value": "9px",
         "uuid": "2444d220-a3d0-4565-a762-02cbc52f828a"
       }
-    }
+    },
+    "uuid": "4058d0b0-ef8a-4e58-b7ed-e2c5444e91c0"
   },
   "table-row-checkbox-to-top-small-regular": {
     "component": "table",
@@ -6005,7 +6363,8 @@
         "value": "14px",
         "uuid": "a63aa24e-c956-4af5-bf4f-4c5d44bd1e16"
       }
-    }
+    },
+    "uuid": "4563310d-c53b-4b39-b5d2-62cbfe5356d9"
   },
   "table-row-checkbox-to-top-small-spacious": {
     "component": "table",
@@ -6021,7 +6380,8 @@
         "value": "19px",
         "uuid": "6ccbecd6-a1c4-4fcf-beb5-2b124ac3e75b"
       }
-    }
+    },
+    "uuid": "f383d370-a44b-458a-8bd0-4c81eb950354"
   },
   "table-row-checkbox-to-top-medium-compact": {
     "component": "table",
@@ -6037,7 +6397,8 @@
         "value": "13px",
         "uuid": "84f00d87-c0ea-42fd-8477-9fff028bf79c"
       }
-    }
+    },
+    "uuid": "68f1090f-9c50-4537-87a4-7a27756c977a"
   },
   "table-row-checkbox-to-top-medium-regular": {
     "component": "table",
@@ -6053,7 +6414,8 @@
         "value": "18px",
         "uuid": "36505a4f-01b6-4b83-adf1-592818eb2c0d"
       }
-    }
+    },
+    "uuid": "e0871753-cee6-4b06-8ca9-faa5348a38ee"
   },
   "table-row-checkbox-to-top-medium-spacious": {
     "component": "table",
@@ -6069,7 +6431,8 @@
         "value": "23px",
         "uuid": "a57d2d1a-5e0c-4d4c-84eb-dd2339366aad"
       }
-    }
+    },
+    "uuid": "3a1bedbe-d6de-4d9e-bc1f-2389dce615c9"
   },
   "table-row-checkbox-to-top-large-compact": {
     "component": "table",
@@ -6085,7 +6448,8 @@
         "value": "17px",
         "uuid": "5fde3b28-c553-4124-be3b-212d1407780c"
       }
-    }
+    },
+    "uuid": "a373d470-cce5-4222-9cdb-3b570018870b"
   },
   "table-row-checkbox-to-top-large-regular": {
     "component": "table",
@@ -6101,7 +6465,8 @@
         "value": "22px",
         "uuid": "2e16e4ef-fec6-41fb-9d96-bc6bb6c88f69"
       }
-    }
+    },
+    "uuid": "3d78defe-7854-4ee6-b6d6-81ac8f6d8854"
   },
   "table-row-checkbox-to-top-large-spacious": {
     "component": "table",
@@ -6117,7 +6482,8 @@
         "value": "27px",
         "uuid": "cfbd6cb5-c8d3-4908-a77a-7a15cda932fb"
       }
-    }
+    },
+    "uuid": "0360a0ce-7b68-4aca-84e5-916773dc6785"
   },
   "table-row-checkbox-to-top-extra-large-compact": {
     "component": "table",
@@ -6133,7 +6499,8 @@
         "value": "21px",
         "uuid": "4069e932-339a-495d-bb36-c89f22af4f96"
       }
-    }
+    },
+    "uuid": "494f8ddd-dda5-4ce1-9df4-77992f55db28"
   },
   "table-row-checkbox-to-top-extra-large-regular": {
     "component": "table",
@@ -6149,7 +6516,8 @@
         "value": "26px",
         "uuid": "2171aee7-d013-459e-a13f-33075090cbe3"
       }
-    }
+    },
+    "uuid": "09aa25e6-1844-45c7-b581-574e21e8c7fd"
   },
   "table-row-checkbox-to-top-extra-large-spacious": {
     "component": "table",
@@ -6165,7 +6533,8 @@
         "value": "31px",
         "uuid": "683be05e-f8d4-4910-8d07-20515f19fbbd"
       }
-    }
+    },
+    "uuid": "69b2f2e6-e886-4f13-bbb1-6f0a44ca1296"
   },
   "table-section-header-row-height-small": {
     "component": "table",
@@ -6181,7 +6550,8 @@
         "value": "30px",
         "uuid": "2cd8dc05-2f95-45b5-b8a4-0273baf3ba0e"
       }
-    }
+    },
+    "uuid": "3f58f0b4-9a45-40c4-b6db-5771fb713690"
   },
   "table-section-header-row-height-medium": {
     "component": "table",
@@ -6197,7 +6567,8 @@
         "value": "40px",
         "uuid": "07beb872-72a0-400e-b434-dd076c9be0a7"
       }
-    }
+    },
+    "uuid": "15e952af-a5c8-465c-b260-ae3e1c074fa7"
   },
   "table-section-header-row-height-large": {
     "component": "table",
@@ -6213,7 +6584,8 @@
         "value": "50px",
         "uuid": "cc41c4f1-bfc5-4aa5-87af-97f191cc7af3"
       }
-    }
+    },
+    "uuid": "35b369fa-8877-4216-b5b6-a4d9100351a4"
   },
   "table-section-header-row-height-extra-large": {
     "component": "table",
@@ -6229,7 +6601,8 @@
         "value": "60px",
         "uuid": "06164331-9a76-4adf-b859-82074df19fbd"
       }
-    }
+    },
+    "uuid": "7155693f-4281-47ad-b02c-d8084756590f"
   },
   "table-thumbnail-to-top-minimum-small-compact": {
     "component": "table",
@@ -6245,7 +6618,8 @@
         "value": "5px",
         "uuid": "72ebb8a4-9bfb-4ff0-ba3a-232c885931e7"
       }
-    }
+    },
+    "uuid": "cae9f1fb-d746-41bc-89ba-58d2aeed2bb8"
   },
   "table-thumbnail-to-top-minimum-medium-compact": {
     "component": "table",
@@ -6261,7 +6635,8 @@
         "value": "6px",
         "uuid": "b546eac7-00ad-4ea2-992d-0c4b8d087679"
       }
-    }
+    },
+    "uuid": "23f99b75-e5a0-4f28-bffc-77c9c3011da9"
   },
   "table-thumbnail-to-top-minimum-large-compact": {
     "component": "table",
@@ -6277,7 +6652,8 @@
         "value": "9px",
         "uuid": "891cf7bc-419a-4b78-8c7e-03685fbf36a4"
       }
-    }
+    },
+    "uuid": "54d5a37b-0edf-4f32-9ad1-794ffaea774b"
   },
   "table-thumbnail-to-top-minimum-extra-large-compact": {
     "component": "table",
@@ -6293,7 +6669,8 @@
         "value": "10px",
         "uuid": "29ee801a-95bd-495c-9905-f2fd00ae0e19"
       }
-    }
+    },
+    "uuid": "d01f46c2-825e-42d4-a1cd-e0f8237833a8"
   },
   "table-thumbnail-to-top-minimum-small-regular": {
     "component": "table",
@@ -6309,7 +6686,8 @@
         "value": "6px",
         "uuid": "e25b14a7-cb9e-406b-bab6-b27575f00a52"
       }
-    }
+    },
+    "uuid": "0df6024f-a4e7-4705-8640-1b561982b514"
   },
   "table-thumbnail-to-top-minimum-medium-regular": {
     "component": "table",
@@ -6325,7 +6703,8 @@
         "value": "9px",
         "uuid": "75af7a67-e0ae-4f41-9c70-09babbc587d1"
       }
-    }
+    },
+    "uuid": "bfa8f410-1d96-4262-bbc0-11b0829e2b17"
   },
   "table-thumbnail-to-top-minimum-large-regular": {
     "component": "table",
@@ -6341,7 +6720,8 @@
         "value": "10px",
         "uuid": "fc7efe7c-ef97-424f-89c2-2211daf44b4a"
       }
-    }
+    },
+    "uuid": "237eb135-271c-4235-a5b9-a3a697fccf96"
   },
   "table-thumbnail-to-top-minimum-extra-large-regular": {
     "component": "table",
@@ -6357,7 +6737,8 @@
         "value": "10px",
         "uuid": "b60c33b8-acc1-4af1-b30f-b467054ee417"
       }
-    }
+    },
+    "uuid": "e9a7b195-264b-44ba-b45a-b80b420139bf"
   },
   "table-thumbnail-to-top-minimum-small-spacious": {
     "component": "table",
@@ -6373,7 +6754,8 @@
         "value": "9px",
         "uuid": "b6684bce-531d-420a-befc-b4ad884059fc"
       }
-    }
+    },
+    "uuid": "210ec248-99f8-4969-a487-0e25140c9431"
   },
   "table-thumbnail-to-top-minimum-medium-spacious": {
     "component": "table",
@@ -6389,7 +6771,8 @@
         "value": "10px",
         "uuid": "0cb1e46b-039b-46d2-a024-b72ddd82d0b4"
       }
-    }
+    },
+    "uuid": "2c9a1114-c7d0-4aeb-bd08-61645357d882"
   },
   "table-thumbnail-to-top-minimum-large-spacious": {
     "component": "table",
@@ -6405,7 +6788,8 @@
         "value": "10px",
         "uuid": "e6689bf9-6ecc-4900-b8ad-85b103232e3e"
       }
-    }
+    },
+    "uuid": "43917cdf-4e06-47a2-935c-47cd42a26349"
   },
   "table-thumbnail-to-top-minimum-extra-large-spacious": {
     "component": "table",
@@ -6421,7 +6805,8 @@
         "value": "12px",
         "uuid": "28a5df8a-0fe4-4410-b804-9a6c26de4440"
       }
-    }
+    },
+    "uuid": "8b294228-b51e-4b2a-b577-4f328170f072"
   },
   "tab-item-height-small": {
     "component": "tabs",
@@ -6485,7 +6870,8 @@
         "value": "27px",
         "uuid": "8b5e1596-f13a-4786-b0c7-f01615423922"
       }
-    }
+    },
+    "uuid": "bc5ff4f1-ac72-47e1-8423-9f8835043c71"
   },
   "tab-item-to-tab-item-horizontal-medium": {
     "component": "tabs",
@@ -6501,7 +6887,8 @@
         "value": "30px",
         "uuid": "885a7cc3-8873-4cb7-99e7-b17f42fb48f1"
       }
-    }
+    },
+    "uuid": "ba8f899f-fa40-4295-92bb-a46d62d891c6"
   },
   "tab-item-to-tab-item-horizontal-large": {
     "component": "tabs",
@@ -6517,7 +6904,8 @@
         "value": "33px",
         "uuid": "71bdfd06-4672-464f-b787-9a62137b1763"
       }
-    }
+    },
+    "uuid": "136e9e3b-104d-42a7-9ff3-9a81b82a224f"
   },
   "tab-item-to-tab-item-horizontal-extra-large": {
     "component": "tabs",
@@ -6533,7 +6921,8 @@
         "value": "36px",
         "uuid": "482ed7f6-ba60-4110-85c8-daf5bf352406"
       }
-    }
+    },
+    "uuid": "c1bdb5e6-754c-4846-9fb4-f9e748ab47eb"
   },
   "tab-item-to-tab-item-vertical-small": {
     "component": "tabs",
@@ -6549,7 +6938,8 @@
         "value": "5px",
         "uuid": "d51a6c05-67d0-425f-becf-86e783ab3305"
       }
-    }
+    },
+    "uuid": "26f918df-58db-4c93-b384-24f4eb5787c7"
   },
   "tab-item-to-tab-item-vertical-medium": {
     "component": "tabs",
@@ -6565,7 +6955,8 @@
         "value": "5px",
         "uuid": "6b6c960f-adcf-48b0-8310-ba12b47f4d9a"
       }
-    }
+    },
+    "uuid": "f38a8014-9b74-4c18-97b8-a3552b08ba2c"
   },
   "tab-item-to-tab-item-vertical-large": {
     "component": "tabs",
@@ -6581,7 +6972,8 @@
         "value": "6px",
         "uuid": "c193b2ee-a584-41dc-9ef8-3aebb38fb832"
       }
-    }
+    },
+    "uuid": "76eca7ae-ce9a-4ce2-8efd-b73f76f03f05"
   },
   "tab-item-to-tab-item-vertical-extra-large": {
     "component": "tabs",
@@ -6597,7 +6989,8 @@
         "value": "6px",
         "uuid": "ea902ec1-25d5-47c3-896a-a95d9ca5bd62"
       }
-    }
+    },
+    "uuid": "b21c35fc-16d6-4356-941b-dc8eb533d524"
   },
   "tab-item-start-to-edge-quiet": {
     "component": "tabs",
@@ -6619,7 +7012,8 @@
         "value": "13px",
         "uuid": "8d413f56-6634-49c8-8d6a-53d0f57f1bbc"
       }
-    }
+    },
+    "uuid": "4c91d4af-7738-41ae-884b-f51b96f0277d"
   },
   "tab-item-start-to-edge-medium": {
     "component": "tabs",
@@ -6635,7 +7029,8 @@
         "value": "15px",
         "uuid": "229477d5-e21a-4f4b-a24d-580f0c60eec5"
       }
-    }
+    },
+    "uuid": "854c8fee-224a-4fca-aeb1-c770faf5ba22"
   },
   "tab-item-start-to-edge-large": {
     "component": "tabs",
@@ -6651,7 +7046,8 @@
         "value": "17px",
         "uuid": "2c85fa9a-e854-46f6-bc6b-547692d08290"
       }
-    }
+    },
+    "uuid": "31935ef9-f6f2-45f0-b2dc-8fb0a105d243"
   },
   "tab-item-start-to-edge-extra-large": {
     "component": "tabs",
@@ -6667,7 +7063,8 @@
         "value": "19px",
         "uuid": "4e0b2015-06c8-41ab-9e2b-3a332a7625ff"
       }
-    }
+    },
+    "uuid": "98e8e273-af5b-413a-a69e-3f7555275ff8"
   },
   "tab-item-top-to-text-small": {
     "component": "tabs",
@@ -6683,7 +7080,8 @@
         "value": "14px",
         "uuid": "3e155b8c-6cea-4b59-817c-cf71a63e00c7"
       }
-    }
+    },
+    "uuid": "f5774cb8-13a1-4473-a48e-ad31031c6633"
   },
   "tab-item-bottom-to-text-small": {
     "component": "tabs",
@@ -6699,7 +7097,8 @@
         "value": "15px",
         "uuid": "e0791360-b505-492b-bf71-dfa393abecfa"
       }
-    }
+    },
+    "uuid": "9fc2a1ef-aadd-4e70-9fda-0b1a4c5e34ef"
   },
   "tab-item-top-to-text-medium": {
     "component": "tabs",
@@ -6715,7 +7114,8 @@
         "value": "18px",
         "uuid": "a8c455e9-60e5-4838-bc9c-eaf7b39a4bf7"
       }
-    }
+    },
+    "uuid": "76b24ca3-192e-4f08-861d-a85bfaf5785e"
   },
   "tab-item-bottom-to-text-medium": {
     "component": "tabs",
@@ -6731,7 +7131,8 @@
         "value": "19px",
         "uuid": "691db84a-5336-4e45-bf73-ee617057e718"
       }
-    }
+    },
+    "uuid": "440bf748-a58c-46d0-b8b8-9a19e9ee5924"
   },
   "tab-item-top-to-text-large": {
     "component": "tabs",
@@ -6747,7 +7148,8 @@
         "value": "22px",
         "uuid": "7e3db5ca-cd32-464b-9a23-9d03e83faa9c"
       }
-    }
+    },
+    "uuid": "90e17fcf-a054-4aab-828a-bc6a21ab17ca"
   },
   "tab-item-bottom-to-text-large": {
     "component": "tabs",
@@ -6763,7 +7165,8 @@
         "value": "22px",
         "uuid": "31d1b6b6-721f-4474-ba86-795367399e49"
       }
-    }
+    },
+    "uuid": "13aa806b-c355-452d-9f9b-c8333a382004"
   },
   "tab-item-top-to-text-extra-large": {
     "component": "tabs",
@@ -6779,7 +7182,8 @@
         "value": "25px",
         "uuid": "174cc6c8-9c0a-44c0-b6c7-ea6d337c819b"
       }
-    }
+    },
+    "uuid": "073cc280-e128-49ec-b2d4-372302b1a8a3"
   },
   "tab-item-bottom-to-text-extra-large": {
     "component": "tabs",
@@ -6795,7 +7199,8 @@
         "value": "25px",
         "uuid": "c63380d4-cc26-4299-b227-af2faedfdc74"
       }
-    }
+    },
+    "uuid": "22c953eb-cfd6-469a-b175-3d08edca39e9"
   },
   "tab-item-top-to-text-compact-small": {
     "component": "tabs",
@@ -6811,7 +7216,8 @@
         "value": "5px",
         "uuid": "d37488c4-d489-45bd-9086-8157c5204ae4"
       }
-    }
+    },
+    "uuid": "5a89fcc8-eb6d-49e0-bf9a-50dd94c2e7b9"
   },
   "tab-item-bottom-to-text-compact-small": {
     "component": "tabs",
@@ -6827,7 +7233,8 @@
         "value": "6px",
         "uuid": "f453e51e-3d58-430e-8f17-8b95718dbf34"
       }
-    }
+    },
+    "uuid": "44fbab39-742f-47ec-8135-b216b7302f1f"
   },
   "tab-item-top-to-text-compact-medium": {
     "component": "tabs",
@@ -6843,7 +7250,8 @@
         "value": "9px",
         "uuid": "128757b0-d690-4886-95d5-e9df36182a0f"
       }
-    }
+    },
+    "uuid": "0500b8b8-0ccb-469f-aff4-e2a0de12c30d"
   },
   "tab-item-bottom-to-text-compact-medium": {
     "component": "tabs",
@@ -6859,7 +7267,8 @@
         "value": "10px",
         "uuid": "e69dee42-92da-4ca9-9eb8-97a7860adaba"
       }
-    }
+    },
+    "uuid": "95b1b803-d8d8-4b6d-8cf1-95cd0031acb9"
   },
   "tab-item-top-to-text-compact-large": {
     "component": "tabs",
@@ -6875,7 +7284,8 @@
         "value": "12px",
         "uuid": "fd20b444-38ac-4438-a9ef-32474222e45f"
       }
-    }
+    },
+    "uuid": "3e5acee9-a5c2-4f95-9588-bd11c42a943c"
   },
   "tab-item-bottom-to-text-compact-large": {
     "component": "tabs",
@@ -6891,7 +7301,8 @@
         "value": "14px",
         "uuid": "091144b7-c63b-4827-840d-741cec01432a"
       }
-    }
+    },
+    "uuid": "b03a5d23-f5d5-44d0-9228-3dc0aad65db5"
   },
   "tab-item-top-to-text-compact-extra-large": {
     "component": "tabs",
@@ -6907,7 +7318,8 @@
         "value": "15px",
         "uuid": "9694ebdc-cc88-4584-89f5-10a2c8de686f"
       }
-    }
+    },
+    "uuid": "160a6ac0-ee42-4d75-85db-f5e80c8dacc4"
   },
   "tab-item-bottom-to-text-compact-extra-large": {
     "component": "tabs",
@@ -6923,7 +7335,8 @@
         "value": "17px",
         "uuid": "3641ac9c-5610-4996-a55d-c2a94b2ff9ea"
       }
-    }
+    },
+    "uuid": "4b84c709-39e5-4a23-b1eb-d816e3d14ac7"
   },
   "tab-item-top-to-workflow-icon-small": {
     "component": "tabs",
@@ -6939,7 +7352,8 @@
         "value": "15px",
         "uuid": "923fd09d-8d08-4465-961f-63ac12014206"
       }
-    }
+    },
+    "uuid": "6e4ff6be-da6e-48ca-bb60-99825f5c0f7e"
   },
   "tab-item-top-to-workflow-icon-medium": {
     "component": "tabs",
@@ -6955,7 +7369,8 @@
         "value": "19px",
         "uuid": "820baccf-af24-42a3-9729-99408bc9322f"
       }
-    }
+    },
+    "uuid": "30fd4757-40b5-4e1d-8f56-d544a730f7e1"
   },
   "tab-item-top-to-workflow-icon-large": {
     "component": "tabs",
@@ -6971,7 +7386,8 @@
         "value": "23px",
         "uuid": "4dd99579-949b-4bf9-b022-e8f0c95eae33"
       }
-    }
+    },
+    "uuid": "ad9470a2-2e7e-4141-a6fb-8bd83adeea4b"
   },
   "tab-item-top-to-workflow-icon-extra-large": {
     "component": "tabs",
@@ -6987,7 +7403,8 @@
         "value": "26px",
         "uuid": "5afa2636-7d4c-4d83-b9fc-3c5a52ee4646"
       }
-    }
+    },
+    "uuid": "2be3d88a-12d9-439a-bccc-c4ec1e15bb2e"
   },
   "tab-item-top-to-workflow-icon-compact-small": {
     "component": "tabs",
@@ -7003,7 +7420,8 @@
         "value": "5px",
         "uuid": "b79002d2-bcff-4e8d-a406-e512c7e7d0e3"
       }
-    }
+    },
+    "uuid": "7e860824-a86c-46a8-b274-20e3eb477a06"
   },
   "tab-item-top-to-workflow-icon-compact-medium": {
     "component": "tabs",
@@ -7019,7 +7437,8 @@
         "value": "9px",
         "uuid": "4fb0520b-8c74-4fb7-b279-a3586a06a57e"
       }
-    }
+    },
+    "uuid": "ffe8f0c4-10ca-4ce3-b2e7-9b247041d641"
   },
   "tab-item-top-to-workflow-icon-compact-large": {
     "component": "tabs",
@@ -7035,7 +7454,8 @@
         "value": "13px",
         "uuid": "fad964d8-0020-4583-97ab-7d6565d01bdc"
       }
-    }
+    },
+    "uuid": "11bb3829-22fa-4b5b-a59c-b66be83711d0"
   },
   "tab-item-top-to-workflow-icon-compact-extra-large": {
     "component": "tabs",
@@ -7051,7 +7471,8 @@
         "value": "16px",
         "uuid": "f310e5d7-7435-41a0-b44d-ececff4844f2"
       }
-    }
+    },
+    "uuid": "3d9343a7-3027-4827-b42b-6068016bddf8"
   },
   "tab-item-focus-indicator-gap-small": {
     "component": "tabs",
@@ -7067,7 +7488,8 @@
         "value": "9px",
         "uuid": "5fbc924e-e79e-46c6-8544-c92d7f33bc26"
       }
-    }
+    },
+    "uuid": "ef063e8e-7195-4364-bf75-768d2511949d"
   },
   "tab-item-focus-indicator-gap-medium": {
     "component": "tabs",
@@ -7083,7 +7505,8 @@
         "value": "10px",
         "uuid": "09ee234f-a596-47ba-89df-ab9ebc07ded8"
       }
-    }
+    },
+    "uuid": "112a9064-c13c-4f0f-b380-2b477f9c8e15"
   },
   "tab-item-focus-indicator-gap-large": {
     "component": "tabs",
@@ -7099,7 +7522,8 @@
         "value": "11px",
         "uuid": "6c4d8c39-9f75-4c75-94e2-274a69a8f556"
       }
-    }
+    },
+    "uuid": "f65bf525-647b-4e29-b0d1-8890511683f8"
   },
   "tab-item-focus-indicator-gap-extra-large": {
     "component": "tabs",
@@ -7115,7 +7539,8 @@
         "value": "12px",
         "uuid": "6c0aad05-5224-4ade-913a-3dc5ebceeb62"
       }
-    }
+    },
+    "uuid": "fec20eb3-b977-442f-92d5-51ab0b4967c9"
   },
   "side-navigation-width": {
     "component": "side-navigation",
@@ -7131,7 +7556,8 @@
         "value": "240px",
         "uuid": "3bc5710f-5fd7-4cce-a3c2-f1e45deee2b2"
       }
-    }
+    },
+    "uuid": "eb372bca-78b4-48fa-9ff3-887a7f3c72f8"
   },
   "side-navigation-minimum-width": {
     "component": "side-navigation",
@@ -7147,7 +7573,8 @@
         "value": "200px",
         "uuid": "ad835d79-64d9-4183-ace0-912c87fc2241"
       }
-    }
+    },
+    "uuid": "51f92ad9-076e-4a1e-a489-ac53cc36f038"
   },
   "side-navigation-maximum-width": {
     "component": "side-navigation",
@@ -7163,7 +7590,8 @@
         "value": "300px",
         "uuid": "bcb163a0-0156-4e2e-abfe-b2ac0158f348"
       }
-    }
+    },
+    "uuid": "d40a2a35-1b20-4be9-afd7-8cfb701faf73"
   },
   "side-navigation-second-level-edge-to-text": {
     "component": "side-navigation",
@@ -7179,7 +7607,8 @@
         "value": "30px",
         "uuid": "e77cde34-8f77-4fd1-a1f7-aa6738130902"
       }
-    }
+    },
+    "uuid": "27097ca6-f105-41cb-822f-5d48e3ea19d6"
   },
   "side-navigation-third-level-edge-to-text": {
     "component": "side-navigation",
@@ -7195,7 +7624,8 @@
         "value": "45px",
         "uuid": "06140452-b779-4527-ae3a-5f0623a6b97c"
       }
-    }
+    },
+    "uuid": "8803e38f-c87b-4c5c-8ae5-c8cbcd5ac6ff"
   },
   "side-navigation-with-icon-second-level-edge-to-text": {
     "component": "side-navigation",
@@ -7211,7 +7641,8 @@
         "value": "62px",
         "uuid": "7d4cd9bd-bfaf-4ad7-9c3b-19f7913f0825"
       }
-    }
+    },
+    "uuid": "6a179e98-012f-449f-97a5-dd9e3532b8a5"
   },
   "side-navigation-with-icon-third-level-edge-to-text": {
     "component": "side-navigation",
@@ -7227,7 +7658,8 @@
         "value": "77px",
         "uuid": "f82ab001-808a-4528-bf4a-be27645a28fc"
       }
-    }
+    },
+    "uuid": "be255625-c2d5-4d63-9823-c1b82c2123f7"
   },
   "side-navigation-item-to-item": {
     "component": "side-navigation",
@@ -7243,7 +7675,8 @@
         "value": "5px",
         "uuid": "be37c65c-88c5-48cd-9554-8240909db98d"
       }
-    }
+    },
+    "uuid": "6d798f26-dbfa-4c26-9d27-4f3b05f33cc4"
   },
   "side-navigation-item-to-header": {
     "component": "side-navigation",
@@ -7259,7 +7692,8 @@
         "value": "30px",
         "uuid": "0f3821f1-6f0e-4325-bfa7-e572768fd468"
       }
-    }
+    },
+    "uuid": "1ceea2e6-fb64-423c-95a7-4406cc6ce849"
   },
   "side-navigation-header-to-item": {
     "component": "side-navigation",
@@ -7275,7 +7709,8 @@
         "value": "10px",
         "uuid": "ad959938-ad69-4137-91e4-fcf2465b223a"
       }
-    }
+    },
+    "uuid": "52645387-83e9-46d4-8d7f-4a4533ee5179"
   },
   "side-navigation-bottom-to-text": {
     "component": "side-navigation",
@@ -7291,7 +7726,8 @@
         "value": "10px",
         "uuid": "e3f49e5e-f9ec-485c-846e-7a8fda08caea"
       }
-    }
+    },
+    "uuid": "0727c8a6-d58d-41e8-8bdc-3a98ff811200"
   },
   "tray-top-to-content-area": {
     "component": "tray",
@@ -7307,7 +7743,8 @@
         "value": "5px",
         "uuid": "794ad497-1725-4a03-a7c9-425eaee3178e"
       }
-    }
+    },
+    "uuid": "f1641c53-fc37-4eeb-ac30-3c5131ed0233"
   },
   "in-field-button-width-stacked-small": {
     "component": "in-field-button",
@@ -7347,7 +7784,8 @@
         "value": "1px",
         "uuid": "5a3e434f-f915-4a72-985b-04af51c3ad7e"
       }
-    }
+    },
+    "uuid": "5cd31637-78a0-4d60-9d8f-8f07f5ba155e"
   },
   "in-field-button-edge-to-fill": {
     "component": "in-field-button",
@@ -7363,7 +7801,8 @@
         "value": "4px",
         "uuid": "670a4fef-5e16-4db6-8acd-b747cc783312"
       }
-    }
+    },
+    "uuid": "8b2c325c-b6ee-4860-a34f-f423a3498a98"
   },
   "in-field-button-stacked-inner-edge-to-fill": {
     "component": "in-field-button",
@@ -7379,7 +7818,8 @@
         "value": "1px",
         "uuid": "c1aa585e-769d-40d6-a42d-c9d602124870"
       }
-    }
+    },
+    "uuid": "36087614-f5ac-46cd-86f9-2dc04796bd44"
   },
   "in-field-button-edge-to-disclosure-icon-stacked-small": {
     "component": "in-field-button",
@@ -7425,7 +7865,8 @@
         "value": "5px",
         "uuid": "b942ec2c-f70f-4948-8ff5-0bd471cd4f0a"
       }
-    }
+    },
+    "uuid": "04a422cc-3370-44a1-9e55-b4e8260b5958"
   },
   "in-field-button-outer-edge-to-disclosure-icon-stacked-large": {
     "component": "in-field-button",
@@ -7441,7 +7882,8 @@
         "value": "7px",
         "uuid": "345002c5-88fc-4297-aa91-54ed292265b8"
       }
-    }
+    },
+    "uuid": "e68a6c5f-6db6-4ef7-ac1c-9379c356d980"
   },
   "in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large": {
     "component": "in-field-button",
@@ -7457,7 +7899,8 @@
         "value": "8px",
         "uuid": "33e443d8-3e31-4f17-ab37-61beebaa9d40"
       }
-    }
+    },
+    "uuid": "4f1d0ee9-6276-42fc-824e-a8362a6140c0"
   },
   "in-field-button-inner-edge-to-disclosure-icon-stacked-small": {
     "component": "in-field-button",
@@ -7473,7 +7916,8 @@
         "value": "1px",
         "uuid": "ec74220b-c091-4b29-8e43-9d3f0e163820"
       }
-    }
+    },
+    "uuid": "afbf364e-a945-42fe-beaf-0177a9203cc4"
   },
   "in-field-button-inner-edge-to-disclosure-icon-stacked-medium": {
     "component": "in-field-button",
@@ -7489,7 +7933,8 @@
         "value": "1px",
         "uuid": "5bddcd79-3829-4764-853a-b83512b5820d"
       }
-    }
+    },
+    "uuid": "2f516c6f-df04-43ec-9890-151201764c40"
   },
   "in-field-button-inner-edge-to-disclosure-icon-stacked-large": {
     "component": "in-field-button",
@@ -7505,7 +7950,8 @@
         "value": "3px",
         "uuid": "7135afd9-ef05-4909-8b3e-eeae3d527bd0"
       }
-    }
+    },
+    "uuid": "cf1518d0-7040-4ac7-87b7-210518ceb7d1"
   },
   "in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large": {
     "component": "in-field-button",
@@ -7521,7 +7967,8 @@
         "value": "4px",
         "uuid": "979542c9-2328-495c-8abf-cb226b140f82"
       }
-    }
+    },
+    "uuid": "e2f9f620-b8f0-4fb7-a9b0-e78f13a0ac03"
   },
   "accordion-top-to-text-spacious-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -7537,6 +7984,7 @@
         "value": "12px",
         "uuid": "02e96927-9f33-4878-9ce0-bb825be84bcb"
       }
-    }
+    },
+    "uuid": "bdf7a208-dbfa-4a66-9138-baec261d2908"
   }
 }

--- a/packages/tokens/src/layout.json
+++ b/packages/tokens/src/layout.json
@@ -24,9 +24,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "a02a1154-142f-43bf-b3d7-91dafdc4a40d"
           }
-        }
+        },
+        "uuid": "8876ffa3-b0af-4cf5-ae8d-5c4ae3766cca"
       }
-    }
+    },
+    "uuid": "bc4c5fdb-7456-4178-8c3b-4aaaa65805a6"
   },
   "corner-radius-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -44,7 +46,8 @@
             "value": "5px",
             "uuid": "e22537bb-a29f-47e5-be13-7e2775ee1103"
           }
-        }
+        },
+        "uuid": "67b83ee8-2782-48a5-ba27-70f690c95b4a"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -63,9 +66,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "2bc66f64-7546-4501-9604-d40759b10062"
           }
-        }
+        },
+        "uuid": "179b1a27-66f9-47b9-9af9-648c0a3dbbfb"
       }
-    }
+    },
+    "uuid": "6063a01d-8ba8-40ab-9c5e-a2112db74fee"
   },
   "corner-radius-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -83,7 +88,8 @@
             "value": "10px",
             "uuid": "23f751eb-a076-487d-a5e1-1c0eb2937018"
           }
-        }
+        },
+        "uuid": "39fdb6a8-579e-4a14-8cee-f2f877efa262"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -102,9 +108,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "c6a87683-3fc2-494a-9650-8edc3d75cba9"
           }
-        }
+        },
+        "uuid": "91db63f4-2719-4d6a-8817-3518bd163e40"
       }
-    }
+    },
+    "uuid": "c8beb921-82c4-48ee-be9e-aab8b4b41a35"
   },
   "drop-shadow-x": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -131,9 +139,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "d40c3468-2f10-41be-940b-96933464efae"
           }
-        }
+        },
+        "uuid": "38b1404c-eb80-493f-acc2-305017351d4b"
       }
-    }
+    },
+    "uuid": "55d07ba8-ccf3-4374-97c4-3ad927edbdd2"
   },
   "drop-shadow-y": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -151,7 +161,8 @@
             "value": "2px",
             "uuid": "32950bbd-7292-452d-a445-4eb6de66c77d"
           }
-        }
+        },
+        "uuid": "03b1bdf3-05d0-4557-999d-d33b4720113a"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -170,9 +181,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "a4213f34-f0ee-45a1-a2ed-225bbe0ec857"
           }
-        }
+        },
+        "uuid": "5b5d8ba2-7724-4e26-889c-a7cea9bbfa1c"
       }
-    }
+    },
+    "uuid": "859114f3-d2a6-4b2e-80c5-118e44ce9cf6"
   },
   "drop-shadow-blur": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -190,7 +203,8 @@
             "value": "6px",
             "uuid": "374f321e-8b0b-442b-9494-6a2ae9936c6b"
           }
-        }
+        },
+        "uuid": "02eb1f7e-4bce-444f-bf93-0a45ab56806a"
       },
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -209,9 +223,11 @@
             "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
             "uuid": "2529adec-ab2e-4e04-aa83-fa9cdd7df1f2"
           }
-        }
+        },
+        "uuid": "0682005e-7411-4680-9db7-6df9482f5b95"
       }
-    }
+    },
+    "uuid": "056dbbc1-ea92-4d56-9928-b14311af8726"
   },
   "android-elevation": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
@@ -291,7 +307,8 @@
         "value": "8px",
         "uuid": "8588bf80-96df-40fb-8b6f-61d06899f8dd"
       }
-    }
+    },
+    "uuid": "45ffa741-ec89-407b-83c2-39e6804308f8"
   },
   "text-to-visual-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -306,7 +323,8 @@
         "value": "9px",
         "uuid": "77dc4cd4-8e4e-4873-b6f3-d573eb7fc315"
       }
-    }
+    },
+    "uuid": "d9b8cf33-161d-4b3b-9c7d-7f5360a94e64"
   },
   "text-to-visual-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -321,7 +339,8 @@
         "value": "10px",
         "uuid": "09d55113-8d94-429f-b0c8-ffabe8ccba27"
       }
-    }
+    },
+    "uuid": "b877c328-b5bd-48f1-9fdc-4a6c557313bb"
   },
   "text-to-visual-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -336,7 +355,8 @@
         "value": "11px",
         "uuid": "dc4ec555-72eb-4328-aba4-e8d594102f45"
       }
-    }
+    },
+    "uuid": "90cae9f7-835c-4851-95eb-cce34d453c20"
   },
   "text-to-visual-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -351,7 +371,8 @@
         "value": "13px",
         "uuid": "205f0c77-6588-4cc7-927f-3ba767200bac"
       }
-    }
+    },
+    "uuid": "add08b8b-d180-4fa6-badb-a766187ceb6b"
   },
   "text-to-control-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -366,7 +387,8 @@
         "value": "11px",
         "uuid": "45f94495-0f53-42b2-94f6-7a6d91eb2ca1"
       }
-    }
+    },
+    "uuid": "575fe03c-2997-4492-ba59-f590aa34820c"
   },
   "text-to-control-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -381,7 +403,8 @@
         "value": "13px",
         "uuid": "b4ce04fa-bc03-44c9-afef-a38810ac9c65"
       }
-    }
+    },
+    "uuid": "4870a9a6-d2c6-4d6d-befb-933921c3d182"
   },
   "text-to-control-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -396,7 +419,8 @@
         "value": "14px",
         "uuid": "8991287c-763f-4a39-ad5b-7ccdbc39b3f6"
       }
-    }
+    },
+    "uuid": "e6dca753-d2f4-4502-9ea4-2d632a8f40de"
   },
   "text-to-control-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -411,7 +435,8 @@
         "value": "16px",
         "uuid": "53a33d46-8d81-4f13-8c79-c4d9257a5b68"
       }
-    }
+    },
+    "uuid": "081770e3-71c4-4ffb-b2e0-92ca7879c4cb"
   },
   "component-height-50": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -426,7 +451,8 @@
         "value": "26px",
         "uuid": "fede8012-f00b-412b-8981-16f60a6133ab"
       }
-    }
+    },
+    "uuid": "13c3b57a-2950-4189-883d-844443ec0645"
   },
   "component-height-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -441,7 +467,8 @@
         "value": "30px",
         "uuid": "5f363452-6317-4e7c-965a-291b3dfa8a8f"
       }
-    }
+    },
+    "uuid": "1a38cc62-cb04-411e-b930-a851e2a9fc80"
   },
   "component-height-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -456,7 +483,8 @@
         "value": "40px",
         "uuid": "5c31197d-0412-469d-a2dd-684efbd4b7e6"
       }
-    }
+    },
+    "uuid": "86326f77-c65f-472f-b440-828f5735dbb6"
   },
   "component-height-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -471,7 +499,8 @@
         "value": "50px",
         "uuid": "7c69efb5-bde7-4ee0-ad1e-2f20e85ebc24"
       }
-    }
+    },
+    "uuid": "cd07b99a-ce5c-4bc8-bbb8-fa56124cf8ee"
   },
   "component-height-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -486,7 +515,8 @@
         "value": "60px",
         "uuid": "53c665a4-83ae-45f2-b90d-33ce52430b84"
       }
-    }
+    },
+    "uuid": "dbbbffcf-cf35-4a0e-993e-488a6becc72f"
   },
   "component-height-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -501,7 +531,8 @@
         "value": "70px",
         "uuid": "4fcbb85f-afbe-41bc-a979-dc09fb98946a"
       }
-    }
+    },
+    "uuid": "47e795c1-92ce-4f6c-8f90-a658746ab0d1"
   },
   "component-height-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -516,7 +547,8 @@
         "value": "80px",
         "uuid": "8135e75c-9536-4743-ab6d-05ed5adb0448"
       }
-    }
+    },
+    "uuid": "44c5972b-cd50-4fc6-b3e6-e65400f0d611"
   },
   "focus-indicator-thickness": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
@@ -543,7 +575,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "84d5fd5a-8245-44b0-8ce5-2ca22a0bc75c"
       }
-    }
+    },
+    "uuid": "e5837232-9892-47ec-b8cc-91920283697a"
   },
   "border-width-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
@@ -568,7 +601,8 @@
         "value": "13px",
         "uuid": "64343da6-f1a6-4615-b2b8-41f9509679e5"
       }
-    }
+    },
+    "uuid": "8e75a202-e6ad-41b5-bdb4-5a9c6adcfb35"
   },
   "component-pill-edge-to-visual-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -583,7 +617,8 @@
         "value": "17px",
         "uuid": "14624bfc-b08f-4637-991b-94a703a7b808"
       }
-    }
+    },
+    "uuid": "4fe71ba1-df88-4ba4-b684-ee01862e6b16"
   },
   "component-pill-edge-to-visual-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -598,7 +633,8 @@
         "value": "22px",
         "uuid": "053363f2-5b8e-4365-8353-3cffac169608"
       }
-    }
+    },
+    "uuid": "5f14c09d-8b25-4a83-9804-d04d510dd78c"
   },
   "component-pill-edge-to-visual-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -613,7 +649,8 @@
         "value": "27px",
         "uuid": "7ae3b6ee-2f80-4596-9d4a-08a5bf9612a7"
       }
-    }
+    },
+    "uuid": "b62d9c6a-c3be-4352-836d-603f3c54b175"
   },
   "component-pill-edge-to-visual-only-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -628,7 +665,8 @@
         "value": "5px",
         "uuid": "7332a4d3-3775-4247-a4c0-fb01f0604d63"
       }
-    }
+    },
+    "uuid": "403c6e59-3a0a-4933-8487-8759f27b78ad"
   },
   "component-pill-edge-to-visual-only-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -643,7 +681,8 @@
         "value": "9px",
         "uuid": "cf58ae75-8f3f-4b9e-809b-ee78abbb2f2f"
       }
-    }
+    },
+    "uuid": "5fbb20c1-14c1-46f7-97c9-9268b86ecda6"
   },
   "component-pill-edge-to-visual-only-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -658,7 +697,8 @@
         "value": "13px",
         "uuid": "989aee4c-5c90-454a-b68d-a7564669c2bd"
       }
-    }
+    },
+    "uuid": "97f2e11f-7776-4c91-8d31-c53c0ba948bc"
   },
   "component-pill-edge-to-visual-only-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -673,7 +713,8 @@
         "value": "16px",
         "uuid": "cb4f356c-2dcd-4043-8f5c-3da904716b48"
       }
-    }
+    },
+    "uuid": "340e4059-a57e-4f8a-84ff-f1a249803b6e"
   },
   "component-pill-edge-to-text-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -688,7 +729,8 @@
         "value": "15px",
         "uuid": "8a23edfc-b993-48bb-917f-377051e02dff"
       }
-    }
+    },
+    "uuid": "7d21104f-2c26-4b3a-85d7-7d6ca0f4dc40"
   },
   "component-pill-edge-to-text-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -703,7 +745,8 @@
         "value": "20px",
         "uuid": "10e326b3-bcce-47df-a1ab-0e3ab9964dd2"
       }
-    }
+    },
+    "uuid": "626e4e4d-99ca-428c-9cde-0db795355a72"
   },
   "component-pill-edge-to-text-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -718,7 +761,8 @@
         "value": "25px",
         "uuid": "c77f6b68-32b7-499c-81d9-50855cc68279"
       }
-    }
+    },
+    "uuid": "f8f40a41-0cb2-40d8-a3fd-17470087db9a"
   },
   "component-pill-edge-to-text-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -733,7 +777,8 @@
         "value": "30px",
         "uuid": "dd7bc474-d5f1-46fe-8a6e-b1645c34c982"
       }
-    }
+    },
+    "uuid": "3e2dc939-a6c5-4654-bfe8-cf74f53cc75a"
   },
   "component-edge-to-visual-50": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -748,7 +793,8 @@
         "value": "7px",
         "uuid": "0b157417-e40f-481c-87e3-8563d55b3135"
       }
-    }
+    },
+    "uuid": "7fb10519-3f10-4ba2-8332-4ff4472eac8c"
   },
   "component-edge-to-visual-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -763,7 +809,8 @@
         "value": "9px",
         "uuid": "acc3e1b9-532d-485e-84e4-06e744c744b3"
       }
-    }
+    },
+    "uuid": "ba705d7c-f284-4236-8167-a9e5594fd8f1"
   },
   "component-edge-to-visual-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -778,7 +825,8 @@
         "value": "12px",
         "uuid": "e77f525e-5043-49c1-a663-9f6c30067043"
       }
-    }
+    },
+    "uuid": "8403ddee-81cf-4d2c-b370-93b3b22669d7"
   },
   "component-edge-to-visual-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -793,7 +841,8 @@
         "value": "16px",
         "uuid": "85f7f49a-7b87-4e2f-b44e-70e3ccde6291"
       }
-    }
+    },
+    "uuid": "82dbca52-b2a9-443a-a853-2d34b003e6d8"
   },
   "component-edge-to-visual-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -808,7 +857,8 @@
         "value": "19px",
         "uuid": "4973c83c-792d-4bc1-9e3d-d047993292ba"
       }
-    }
+    },
+    "uuid": "c2a9eb95-d607-4ed2-b565-64782e1764cf"
   },
   "component-edge-to-visual-only-50": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -823,7 +873,8 @@
         "value": "4px",
         "uuid": "fd1c11a6-53d5-4253-a7d7-c4131c4b1a5e"
       }
-    }
+    },
+    "uuid": "0bcf5bdc-9c4f-4200-a5a4-94373b65a362"
   },
   "component-edge-to-visual-only-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -838,7 +889,8 @@
         "value": "5px",
         "uuid": "5c4f1f7a-2218-4d03-ac83-9750c2c9336b"
       }
-    }
+    },
+    "uuid": "1a2a7e3d-8a64-4194-a8f2-a3cdc4fd716b"
   },
   "component-edge-to-visual-only-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -853,7 +905,8 @@
         "value": "9px",
         "uuid": "93e42bfc-c2f0-40cd-a561-9045c68cb5d1"
       }
-    }
+    },
+    "uuid": "d7116e16-1489-41e3-a3cd-e022bea7467a"
   },
   "component-edge-to-visual-only-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -868,7 +921,8 @@
         "value": "13px",
         "uuid": "9dffd6f3-6230-425e-9208-296cf4d5c185"
       }
-    }
+    },
+    "uuid": "dc62e6e5-8da0-4059-898e-c054f06421eb"
   },
   "component-edge-to-visual-only-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -883,7 +937,8 @@
         "value": "16px",
         "uuid": "090b3da5-0aa3-4bf8-b3bd-dd8dabb40721"
       }
-    }
+    },
+    "uuid": "2a0372fa-c799-41c8-bd8c-6649de123388"
   },
   "component-edge-to-text-50": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -898,7 +953,8 @@
         "value": "10px",
         "uuid": "d660beeb-278b-4157-b6fc-852c680ecae7"
       }
-    }
+    },
+    "uuid": "bb17abc8-9204-4115-8a26-1555561121aa"
   },
   "component-edge-to-text-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -913,7 +969,8 @@
         "value": "11px",
         "uuid": "942f0f34-611a-4318-9b0e-3632e7f520b3"
       }
-    }
+    },
+    "uuid": "a59f2433-297e-4507-88d0-fd86f7f12be7"
   },
   "component-edge-to-text-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -928,7 +985,8 @@
         "value": "15px",
         "uuid": "0b3ecfcf-8fb9-4faf-ab7f-ff4baf733df5"
       }
-    }
+    },
+    "uuid": "f6173de9-ea58-48d0-a15f-f7622701ab4b"
   },
   "component-edge-to-text-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -943,7 +1001,8 @@
         "value": "19px",
         "uuid": "c567f435-928c-4bf8-b9c0-ac2f22d58348"
       }
-    }
+    },
+    "uuid": "17b56bf2-6fb2-47a0-8e45-3586eef29324"
   },
   "component-edge-to-text-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -958,7 +1017,8 @@
         "value": "22px",
         "uuid": "616de468-71fc-4315-87ea-47cdc508a599"
       }
-    }
+    },
+    "uuid": "82f28efb-5fd8-4a77-bc5e-59ff083bf82a"
   },
   "component-top-to-workflow-icon-50": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -973,7 +1033,8 @@
         "value": "4px",
         "uuid": "24853983-c1b0-422d-84b6-05b9313066ed"
       }
-    }
+    },
+    "uuid": "2a08f224-2540-4cc1-ac4e-2f6a51769a5f"
   },
   "component-top-to-workflow-icon-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -988,7 +1049,8 @@
         "value": "5px",
         "uuid": "9d1b0ef4-5433-43fe-aa33-0274ff29f6f3"
       }
-    }
+    },
+    "uuid": "494cd69a-7196-41c7-9817-60bc435c9b40"
   },
   "component-top-to-workflow-icon-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1003,7 +1065,8 @@
         "value": "9px",
         "uuid": "a3d3f9e9-a784-445a-a052-22f84b832512"
       }
-    }
+    },
+    "uuid": "6128dae3-46d7-4948-9095-6506ae501323"
   },
   "component-top-to-workflow-icon-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1018,7 +1081,8 @@
         "value": "13px",
         "uuid": "259c0cf5-d321-4a6b-a3ae-b8c58fc1c9d6"
       }
-    }
+    },
+    "uuid": "7daefac9-1331-4775-913d-4fafc976bc3a"
   },
   "component-top-to-workflow-icon-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1033,7 +1097,8 @@
         "value": "16px",
         "uuid": "bac14298-68f0-4fb6-a152-c95ab19fd27f"
       }
-    }
+    },
+    "uuid": "1a08144d-7a4b-4c3c-89e3-9f50f23a5da7"
   },
   "component-top-to-text-50": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1048,7 +1113,8 @@
         "value": "4px",
         "uuid": "cb2a6539-4cee-420c-aeef-dbdd3220039d"
       }
-    }
+    },
+    "uuid": "0235ab3a-7c70-4e78-9208-8ed4e60ad2d2"
   },
   "component-top-to-text-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1063,7 +1129,8 @@
         "value": "5px",
         "uuid": "54a0e5cf-3e4a-454b-9dba-a6a2c277fa5e"
       }
-    }
+    },
+    "uuid": "b9430981-8544-4a73-912b-f06209e2f6f9"
   },
   "component-top-to-text-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1078,7 +1145,8 @@
         "value": "8px",
         "uuid": "bed358a2-0559-4501-a147-b375887f25af"
       }
-    }
+    },
+    "uuid": "85b23576-1071-4563-80b2-2b6b65755a5d"
   },
   "component-top-to-text-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1093,7 +1161,8 @@
         "value": "12px",
         "uuid": "621c9cf1-02e2-478b-9f47-0804f0183531"
       }
-    }
+    },
+    "uuid": "32131b82-2cf1-45d5-9d94-2663a3585a83"
   },
   "component-top-to-text-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1108,7 +1177,8 @@
         "value": "15px",
         "uuid": "e0ae8c97-73ee-4b09-839f-5ebfb6eb0d7a"
       }
-    }
+    },
+    "uuid": "f9a24565-3414-497c-99e9-16a9f27b3926"
   },
   "component-bottom-to-text-50": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1123,7 +1193,8 @@
         "value": "6px",
         "uuid": "80f01183-a152-4c55-ac11-24edae62df64"
       }
-    }
+    },
+    "uuid": "5960d321-4b6a-4f0c-8e9b-8b59bd483e17"
   },
   "component-bottom-to-text-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1138,7 +1209,8 @@
         "value": "6px",
         "uuid": "0f1a6c63-bc4f-444c-9a18-67b6c35464b1"
       }
-    }
+    },
+    "uuid": "47a641c0-5255-4558-9edd-dd525e14f1d0"
   },
   "component-bottom-to-text-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1153,7 +1225,8 @@
         "value": "11px",
         "uuid": "c8590269-dcaa-44f6-9c2d-d33274c3fe5e"
       }
-    }
+    },
+    "uuid": "360272cc-c406-45ca-8a8e-4720a60c5af4"
   },
   "component-bottom-to-text-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1168,7 +1241,8 @@
         "value": "14px",
         "uuid": "a39cef5c-631c-4942-b5d2-9121e05d47f8"
       }
-    }
+    },
+    "uuid": "f1d6de68-8b40-4119-8326-66fd19afafac"
   },
   "component-bottom-to-text-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1183,7 +1257,8 @@
         "value": "18px",
         "uuid": "a6aac364-d617-4e21-a1db-5523daaa3c6c"
       }
-    }
+    },
+    "uuid": "1d0da882-d145-4ede-8c27-42a174d757ec"
   },
   "component-to-menu-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1198,7 +1273,8 @@
         "value": "7px",
         "uuid": "cc2c2606-500a-45e2-b460-2b498dcddb26"
       }
-    }
+    },
+    "uuid": "ed847a42-b5cc-4021-a2c1-047318f63248"
   },
   "component-to-menu-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1213,7 +1289,8 @@
         "value": "8px",
         "uuid": "e8602fbe-1bf9-4aec-9cb0-5b4e994558c9"
       }
-    }
+    },
+    "uuid": "5bd2b0aa-7319-4049-b41f-b002a56144ec"
   },
   "component-to-menu-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1228,7 +1305,8 @@
         "value": "9px",
         "uuid": "b33acdfa-525e-45c6-ab2b-c959760c4024"
       }
-    }
+    },
+    "uuid": "48117dc9-284e-4f67-ad97-18d17e1f9be3"
   },
   "component-to-menu-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1243,7 +1321,8 @@
         "value": "10px",
         "uuid": "9fa90167-54ec-4343-a14c-4cd18963dcc5"
       }
-    }
+    },
+    "uuid": "20a4ee4f-c6c6-4268-bd80-27d5334d11d8"
   },
   "field-edge-to-text-quiet": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
@@ -1283,7 +1362,8 @@
         "value": "9px",
         "uuid": "87d3f491-f45f-4bee-9dbd-00086cca5858"
       }
-    }
+    },
+    "uuid": "a64a38da-9fe3-4af5-8fda-78482db6a1da"
   },
   "field-edge-to-disclosure-icon-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1298,7 +1378,8 @@
         "value": "13px",
         "uuid": "26d578cb-9228-4643-b042-8b00ba4d9b61"
       }
-    }
+    },
+    "uuid": "d36e894c-0d0c-47cc-9cf1-5fc63e5e93e0"
   },
   "field-edge-to-disclosure-icon-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1313,7 +1394,8 @@
         "value": "17px",
         "uuid": "fcc139c1-08ed-4641-932d-5050237abfaa"
       }
-    }
+    },
+    "uuid": "9fd501a5-8840-43ee-b0f5-ba0646b1eee4"
   },
   "field-edge-to-disclosure-icon-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1328,7 +1410,8 @@
         "value": "22px",
         "uuid": "0d3045e2-a493-406a-a247-8d20f35db2d9"
       }
-    }
+    },
+    "uuid": "0baf490e-6524-4b8a-b034-657c3cd5c802"
   },
   "field-end-edge-to-disclosure-icon-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1343,7 +1426,8 @@
         "value": "9px",
         "uuid": "927e7b5a-57b4-4d47-9ad8-e287199e68a3"
       }
-    }
+    },
+    "uuid": "a38d41cf-b4cb-4293-9ba9-152f2350c7ff"
   },
   "field-end-edge-to-disclosure-icon-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1358,7 +1442,8 @@
         "value": "13px",
         "uuid": "7b3ab0f8-8bde-461f-b658-6848d64de0e3"
       }
-    }
+    },
+    "uuid": "7b1baf11-35a1-4ddb-be95-5eee88251e5c"
   },
   "field-end-edge-to-disclosure-icon-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1373,7 +1458,8 @@
         "value": "17px",
         "uuid": "417eb2ee-3fe9-47fc-a122-d466eb4e7b26"
       }
-    }
+    },
+    "uuid": "f75ad2a8-ad22-4c63-9624-15aad22b4d5c"
   },
   "field-end-edge-to-disclosure-icon-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1388,7 +1474,8 @@
         "value": "22px",
         "uuid": "7c2b5cc0-01c0-4e5f-a157-1d2432f8bbc1"
       }
-    }
+    },
+    "uuid": "0f2ae777-813a-42cf-83e8-581823edcb83"
   },
   "field-top-to-disclosure-icon-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1403,7 +1490,8 @@
         "value": "9px",
         "uuid": "2f62718d-3df8-498b-9520-baf8be65f3bd"
       }
-    }
+    },
+    "uuid": "85a92eb8-0462-42f2-8b6f-f4df85bb6618"
   },
   "field-top-to-disclosure-icon-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1418,7 +1506,8 @@
         "value": "13px",
         "uuid": "1357cf8e-6e41-4d3c-be39-9aa87d010b78"
       }
-    }
+    },
+    "uuid": "23b71bea-4132-4147-8b43-c122318f7e43"
   },
   "field-top-to-disclosure-icon-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1433,7 +1522,8 @@
         "value": "17px",
         "uuid": "2af47c9c-dba6-4340-b5fc-af00dcbaa05c"
       }
-    }
+    },
+    "uuid": "86c7337b-7822-4f9b-a9d5-e951329388db"
   },
   "field-top-to-disclosure-icon-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1448,7 +1538,8 @@
         "value": "22px",
         "uuid": "631146ab-f3f2-4ea0-aac1-2bea622d0c85"
       }
-    }
+    },
+    "uuid": "dd1fb027-a246-4582-80f2-b0f99afd74d9"
   },
   "field-top-to-alert-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1463,7 +1554,8 @@
         "value": "5px",
         "uuid": "580b677d-5d7e-4306-87ee-640a4613254b"
       }
-    }
+    },
+    "uuid": "d37b4194-0a79-4fc4-b320-b87dcba9a7ff"
   },
   "field-top-to-alert-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1478,7 +1570,8 @@
         "value": "9px",
         "uuid": "1def1d88-0098-4e00-987f-17a8656047da"
       }
-    }
+    },
+    "uuid": "67a98dd3-363f-4efc-ac13-aed238653431"
   },
   "field-top-to-alert-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1493,7 +1586,8 @@
         "value": "13px",
         "uuid": "6247903e-2c00-4242-b2d5-da2864b6aa87"
       }
-    }
+    },
+    "uuid": "817c73de-49d0-4f27-980e-63578db71c6c"
   },
   "field-top-to-alert-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1508,7 +1602,8 @@
         "value": "16px",
         "uuid": "246058b4-e152-4673-91ab-34384fceb798"
       }
-    }
+    },
+    "uuid": "db3c0afa-1c9d-421e-a577-f61f5e31e5d2"
   },
   "field-top-to-validation-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1523,7 +1618,8 @@
         "value": "9px",
         "uuid": "1a5b6e87-12a8-4fda-a8f7-2928b0b68a46"
       }
-    }
+    },
+    "uuid": "3308b2e4-9057-482d-b5fd-d6d46531cced"
   },
   "field-top-to-validation-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1538,7 +1634,8 @@
         "value": "13px",
         "uuid": "7bb6c4c7-4157-4da9-bf06-1d2527022d6a"
       }
-    }
+    },
+    "uuid": "ab32ee76-c561-43c2-baf7-8c3db125e5c6"
   },
   "field-top-to-validation-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1553,7 +1650,8 @@
         "value": "17px",
         "uuid": "f4f9d889-130a-4e71-9a9c-1ee82c2a4a4b"
       }
-    }
+    },
+    "uuid": "775f3bd0-63ec-43ae-83e6-7f66dea66607"
   },
   "field-top-to-validation-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1568,7 +1666,8 @@
         "value": "22px",
         "uuid": "a6da1cb9-6085-4c58-b3dc-3b1377f64fa4"
       }
-    }
+    },
+    "uuid": "f95ff454-e453-4c6d-be7c-2e01d85728a3"
   },
   "field-top-to-progress-circle-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1583,7 +1682,8 @@
         "value": "7px",
         "uuid": "5da7e575-d0c3-44e7-bbfa-6fa58972343b"
       }
-    }
+    },
+    "uuid": "5bfcdf4a-be6a-45dc-9866-5c57b687629b"
   },
   "field-top-to-progress-circle-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1598,7 +1698,8 @@
         "value": "12px",
         "uuid": "7b4b7283-1223-4d2e-9f24-5ed6dada4711"
       }
-    }
+    },
+    "uuid": "b061d527-c92c-4786-93c4-e51ddb8c97c8"
   },
   "field-top-to-progress-circle-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1613,7 +1714,8 @@
         "value": "17px",
         "uuid": "7a17cc60-fa76-4234-a99e-c4f711e63f5f"
       }
-    }
+    },
+    "uuid": "4a775115-bbe4-4885-aee9-1a74b2a266a6"
   },
   "field-top-to-progress-circle-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1628,7 +1730,8 @@
         "value": "22px",
         "uuid": "263428f7-3b5a-449a-87d1-874cebf50fa8"
       }
-    }
+    },
+    "uuid": "528f5802-0d21-4b83-b997-b8336694c6e8"
   },
   "field-edge-to-alert-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1643,7 +1746,8 @@
         "value": "11px",
         "uuid": "68c4dc34-49cb-4174-bd06-5f5dfbd0b64e"
       }
-    }
+    },
+    "uuid": "0dfba3ee-758b-4cc0-ada5-a1411ff734cd"
   },
   "field-edge-to-alert-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1658,7 +1762,8 @@
         "value": "15px",
         "uuid": "b98d3a2d-94fb-4491-9650-1c9a62365a19"
       }
-    }
+    },
+    "uuid": "6b74a006-ac79-49b9-a16e-fcd43554ac3b"
   },
   "field-edge-to-alert-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1673,7 +1778,8 @@
         "value": "19px",
         "uuid": "a7c0e1fc-bc57-450e-bdc2-1c2cf2823d98"
       }
-    }
+    },
+    "uuid": "883877b4-1b4f-4f52-9016-27b04a72b332"
   },
   "field-edge-to-alert-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1688,7 +1794,8 @@
         "value": "22px",
         "uuid": "2a77de7a-20cb-40a2-b3a9-252fcaa7a7d2"
       }
-    }
+    },
+    "uuid": "0110b7bf-e4ef-4bbd-af35-a3bac8ecdbea"
   },
   "field-edge-to-validation-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1703,7 +1810,8 @@
         "value": "11px",
         "uuid": "a1c55785-3ae3-4c23-81e2-f088e76e4e04"
       }
-    }
+    },
+    "uuid": "281499ca-f0ee-4864-8dee-7f51ab85b706"
   },
   "field-edge-to-validation-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1718,7 +1826,8 @@
         "value": "15px",
         "uuid": "c51f02a2-35d4-460f-9f14-a97d9e8e6616"
       }
-    }
+    },
+    "uuid": "e4d505d2-5109-447a-a47d-57171d653770"
   },
   "field-edge-to-validation-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1733,7 +1842,8 @@
         "value": "19px",
         "uuid": "9525d928-4cdb-4cf5-8616-2024ed6fb7c0"
       }
-    }
+    },
+    "uuid": "c08504fc-9b7a-4bfa-9544-4f6b9a52a0bc"
   },
   "field-edge-to-validation-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1748,7 +1858,8 @@
         "value": "22px",
         "uuid": "539800f6-7bbc-4b67-8b61-99d1ee2f69a4"
       }
-    }
+    },
+    "uuid": "f2b95331-5166-418a-b429-976ef95b95f1"
   },
   "field-text-to-alert-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1763,7 +1874,8 @@
         "value": "10px",
         "uuid": "01ad9b7d-926e-4db4-a86a-a804fdfc7d68"
       }
-    }
+    },
+    "uuid": "52dda1a3-282a-47a2-a867-d846f7f19471"
   },
   "field-text-to-alert-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1778,7 +1890,8 @@
         "value": "15px",
         "uuid": "03d088d2-4ec9-45bc-896d-8423bf72317e"
       }
-    }
+    },
+    "uuid": "fdcd5d41-c5bf-4ec7-9258-d91384403221"
   },
   "field-text-to-alert-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1793,7 +1906,8 @@
         "value": "19px",
         "uuid": "73025a05-6203-460b-830b-458f8109abce"
       }
-    }
+    },
+    "uuid": "3b2c9e64-0eff-47df-afca-60cd8f2f36f2"
   },
   "field-text-to-alert-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1808,7 +1922,8 @@
         "value": "22px",
         "uuid": "ec794a47-71af-42ea-87f2-048fab8dbf9d"
       }
-    }
+    },
+    "uuid": "d2b8b5ce-c2e2-4998-bdd7-9816543d91cb"
   },
   "field-text-to-validation-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1823,7 +1938,8 @@
         "value": "10px",
         "uuid": "c2181581-6aa1-4e1f-80bc-1ca2e85ea01b"
       }
-    }
+    },
+    "uuid": "d017a7c2-6dda-4560-8c96-09f6265f44f5"
   },
   "field-text-to-validation-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1838,7 +1954,8 @@
         "value": "15px",
         "uuid": "87e221ab-fb8c-4d59-9d4b-9815a672cc23"
       }
-    }
+    },
+    "uuid": "cd13895d-54d2-4cec-ad90-e34af8d83ddb"
   },
   "field-text-to-validation-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1853,7 +1970,8 @@
         "value": "19px",
         "uuid": "b28a0156-4930-484c-a518-ee00e0292db5"
       }
-    }
+    },
+    "uuid": "de02692e-742c-428b-9331-edf2984c5198"
   },
   "field-text-to-validation-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1868,7 +1986,8 @@
         "value": "22px",
         "uuid": "8926578a-c326-4a75-aafb-d90112aaedb5"
       }
-    }
+    },
+    "uuid": "f6f8e52f-02ae-4135-8d2d-22bb06e549a4"
   },
   "field-width": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1883,7 +2002,8 @@
         "value": "240px",
         "uuid": "08c2390a-353b-4e6b-b025-dbaeaa5fdff2"
       }
-    }
+    },
+    "uuid": "5f0c388a-b159-412b-aca4-f31a35a28674"
   },
   "character-count-to-field-quiet-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1898,7 +2018,8 @@
         "value": "-4px",
         "uuid": "819cdbf4-9e26-4fdf-895d-8f60c06efa2a"
       }
-    }
+    },
+    "uuid": "23450319-d853-48e0-81dc-70bc7079d8aa"
   },
   "character-count-to-field-quiet-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1913,7 +2034,8 @@
         "value": "-4px",
         "uuid": "1cecea81-8c7f-4658-b3a2-0e1282f7eac9"
       }
-    }
+    },
+    "uuid": "518b6d81-97c9-4ffc-9332-1ad3097c684a"
   },
   "character-count-to-field-quiet-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1928,7 +2050,8 @@
         "value": "-4px",
         "uuid": "cef58f98-9fb0-4fbb-b6aa-dc5786d7658a"
       }
-    }
+    },
+    "uuid": "93632f57-880a-44aa-a0b3-31bdaaee559d"
   },
   "character-count-to-field-quiet-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1943,7 +2066,8 @@
         "value": "-5px",
         "uuid": "2cfe025b-8bf8-47a3-8ff1-733cf62dd182"
       }
-    }
+    },
+    "uuid": "ac67b79b-e1df-4873-b152-75124eb12777"
   },
   "side-label-character-count-to-field": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1958,7 +2082,8 @@
         "value": "15px",
         "uuid": "ec387876-31d5-42a5-99aa-02c5d35e6223"
       }
-    }
+    },
+    "uuid": "ea77b9b5-6b36-48a7-b275-08726a1937cc"
   },
   "side-label-character-count-top-margin-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1973,7 +2098,8 @@
         "value": "5px",
         "uuid": "9196a2ad-67cd-44d8-b4c6-bca25e37eb4a"
       }
-    }
+    },
+    "uuid": "ac75b149-e9f3-45df-aaa6-6a28ebf22458"
   },
   "side-label-character-count-top-margin-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -1988,7 +2114,8 @@
         "value": "10px",
         "uuid": "a2b20c88-d28c-4261-8160-62630c5e0da8"
       }
-    }
+    },
+    "uuid": "8a6d587a-8d04-4f53-b86f-3f8cd17cfa3a"
   },
   "side-label-character-count-top-margin-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2003,7 +2130,8 @@
         "value": "14px",
         "uuid": "ca10a5d6-a8b2-414d-978a-14481e2a21cb"
       }
-    }
+    },
+    "uuid": "53f6909b-3f50-4962-932a-16db7acec5b1"
   },
   "side-label-character-count-top-margin-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2018,7 +2146,8 @@
         "value": "18px",
         "uuid": "c2c4ddf3-f273-4e23-9be0-e1227e9999a8"
       }
-    }
+    },
+    "uuid": "c0972a55-7db7-4425-bd86-9e14688843a0"
   },
   "disclosure-indicator-top-to-disclosure-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2033,7 +2162,8 @@
         "value": "9px",
         "uuid": "d7c1f2a1-b679-42ae-8512-27883d9789f9"
       }
-    }
+    },
+    "uuid": "c8b11a24-76e6-47be-8ccb-d8fc8f9d7b37"
   },
   "disclosure-indicator-top-to-disclosure-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2048,7 +2178,8 @@
         "value": "13px",
         "uuid": "049e0fe7-03d4-4d9b-bdcd-9c8a06852010"
       }
-    }
+    },
+    "uuid": "84ad72d9-2639-4a7f-8300-0a717287cf39"
   },
   "disclosure-indicator-top-to-disclosure-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2063,7 +2194,8 @@
         "value": "17px",
         "uuid": "24dd2c12-17f0-4d38-9af3-a3b112c40c74"
       }
-    }
+    },
+    "uuid": "736e1b2c-75e1-47a8-a238-ac3acebce092"
   },
   "disclosure-indicator-top-to-disclosure-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2078,7 +2210,8 @@
         "value": "22px",
         "uuid": "9c38e8f6-cca7-4f7f-a7c3-9d4ee7af24b8"
       }
-    }
+    },
+    "uuid": "f4459309-c64b-4b7b-8247-6c54cd1810c4"
   },
   "text-underline-thickness": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
@@ -2103,7 +2236,8 @@
         "value": "7px",
         "uuid": "d11ab0de-19bd-4f56-8798-0192fd0cfe0e"
       }
-    }
+    },
+    "uuid": "813ad969-82f0-437b-b595-4d5f4839fc90"
   },
   "navigational-indicator-top-to-back-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2118,7 +2252,8 @@
         "value": "12px",
         "uuid": "74f8a686-0e06-4f7c-9e3d-694749beb420"
       }
-    }
+    },
+    "uuid": "f634deb6-920c-4c14-867e-7b10010ba391"
   },
   "navigational-indicator-top-to-back-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2133,7 +2268,8 @@
         "value": "16px",
         "uuid": "e84bc865-c89f-403e-bb14-2a11f03fd364"
       }
-    }
+    },
+    "uuid": "82bf0b1c-f289-4b90-a033-db1f0affe297"
   },
   "navigational-indicator-top-to-back-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2148,7 +2284,8 @@
         "value": "19px",
         "uuid": "e68f2798-6a55-499a-b591-0cfc130607ba"
       }
-    }
+    },
+    "uuid": "d09f3117-e7d6-48d5-86ef-3652cf176450"
   },
   "color-control-track-width": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -2163,6 +2300,7 @@
         "value": "30px",
         "uuid": "07e3ac46-3f96-4c00-aa6a-09840ee04bdd"
       }
-    }
+    },
+    "uuid": "b844f3de-6179-4326-ad9c-740eb8b7b8d1"
   }
 }

--- a/packages/tokens/src/semantic-color-palette.json
+++ b/packages/tokens/src/semantic-color-palette.json
@@ -14,7 +14,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "f9fc7606-b699-46e7-b139-aeefc287923c"
       }
-    }
+    },
+    "uuid": "0dd9c008-b20f-4a51-be59-67d9530877ff"
   },
   "accent-color-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -31,7 +32,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "78e50d0b-78a0-46c4-8262-417143f00902"
       }
-    }
+    },
+    "uuid": "d4850a3d-cce3-4cd5-ba44-27281cad5934"
   },
   "accent-color-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -48,7 +50,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "d014e1e8-a5f8-4169-8c43-d69afd07847a"
       }
-    }
+    },
+    "uuid": "89c05b32-63f5-46ed-abe1-a36247bd9797"
   },
   "accent-color-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -65,7 +68,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "1b70bc67-7877-4f92-8ce4-1abd2665fab1"
       }
-    }
+    },
+    "uuid": "794b3679-1bcf-4c64-a55b-99be3f7676e5"
   },
   "accent-color-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -82,7 +86,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "06246e8e-44da-49a3-8d65-7f3ce1ec8128"
       }
-    }
+    },
+    "uuid": "6eee723c-d9dd-4b14-ab44-75779c44f59e"
   },
   "accent-color-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -99,7 +104,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "eaee7f34-1725-411e-9a23-2331167e08f5"
       }
-    }
+    },
+    "uuid": "11e391f6-66f0-4ed0-b70a-3f3d3a0e2f90"
   },
   "accent-color-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -116,7 +122,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "5c7ac5cc-4fe4-4392-a5c3-4274cd15a48e"
       }
-    }
+    },
+    "uuid": "fc2868a8-1b1b-4da7-a51f-7faa6e7f7d4d"
   },
   "accent-color-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -133,7 +140,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "3cf62c35-1e2e-4400-886f-473de9e8a958"
       }
-    }
+    },
+    "uuid": "85bd13e9-ff5a-419d-bc33-97fd44cf1789"
   },
   "accent-color-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -150,7 +158,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "42d37753-8b78-4328-a895-7b74d9a7aa86"
       }
-    }
+    },
+    "uuid": "23cb9c14-f3cf-430b-9d0c-4749160542d8"
   },
   "accent-color-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -167,7 +176,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "b848c6ce-f921-4303-b298-20e359a1aa2e"
       }
-    }
+    },
+    "uuid": "203cf947-661e-4e96-8d13-5f0d3e9237bf"
   },
   "accent-color-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -184,7 +194,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "46991cf0-e4e5-4c32-a140-4589e2456523"
       }
-    }
+    },
+    "uuid": "80493b68-bdd4-4478-8ec1-2049922382be"
   },
   "accent-color-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -201,7 +212,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "7de1e3f0-a5b3-4a09-955b-242ff78dbaa9"
       }
-    }
+    },
+    "uuid": "eeed3404-3bde-4bb6-975f-556ec92297bd"
   },
   "accent-color-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -218,7 +230,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "a598813b-347f-4528-aa35-94b6642985db"
       }
-    }
+    },
+    "uuid": "0083814f-7761-4a52-97e3-ca154d7b8603"
   },
   "accent-color-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/system-set.json",
@@ -235,7 +248,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "12c250df-6088-4c20-8b04-59814d53ed7a"
       }
-    }
+    },
+    "uuid": "1124ea0a-6ba1-4b7e-852e-db760d182a97"
   },
   "informative-color-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -72,7 +72,8 @@
         "value": "13px",
         "uuid": "b7561ce1-e12e-4aed-9766-181f7eca309e"
       }
-    }
+    },
+    "uuid": "daa864c1-e91e-4357-bcfc-02f3a5037f9c"
   },
   "font-size-75": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -87,7 +88,8 @@
         "value": "15px",
         "uuid": "07e1c2a8-3925-4d71-8fae-3486483ff44c"
       }
-    }
+    },
+    "uuid": "5cf4dd2a-2a85-4eb6-b163-fa6737e4f838"
   },
   "font-size-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -102,7 +104,8 @@
         "value": "17px",
         "uuid": "2f9ee3cf-ccb1-4f0b-aed6-96e472fb7411"
       }
-    }
+    },
+    "uuid": "86103cc9-4510-45af-8139-a81ea3b69da7"
   },
   "font-size-200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -117,7 +120,8 @@
         "value": "19px",
         "uuid": "7e51ff4e-2749-49d1-b9ed-75de92a73991"
       }
-    }
+    },
+    "uuid": "0cfbf6f7-7e79-44bb-af03-6355f412f590"
   },
   "font-size-300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -132,7 +136,8 @@
         "value": "22px",
         "uuid": "9b9a7175-dcca-43aa-98ce-f1c3e4eefda7"
       }
-    }
+    },
+    "uuid": "cd34b2cb-e7fa-41dd-bd1e-cb1e8113554a"
   },
   "font-size-400": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -147,7 +152,8 @@
         "value": "24px",
         "uuid": "d5ed0e8d-01ac-495f-bd15-fecc30af17c4"
       }
-    }
+    },
+    "uuid": "c5ae539c-9b16-489a-a39b-c9cee1a1701b"
   },
   "font-size-500": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -162,7 +168,8 @@
         "value": "27px",
         "uuid": "a69a5079-1b5b-4ccf-946f-8b6e3fae4d7e"
       }
-    }
+    },
+    "uuid": "ff5914d7-5d19-4b21-b633-c742d95942db"
   },
   "font-size-600": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -177,7 +184,8 @@
         "value": "31px",
         "uuid": "ac892307-2559-48f5-9e2c-98dabbb0abc2"
       }
-    }
+    },
+    "uuid": "ed0c86e1-f062-405e-a1c4-ce74f62c0ea7"
   },
   "font-size-700": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -192,7 +200,8 @@
         "value": "34px",
         "uuid": "6bd6456c-b73b-4926-8e67-7b942e32bbc2"
       }
-    }
+    },
+    "uuid": "b2b59d6e-50f8-4e72-a5c5-993a87971e3d"
   },
   "font-size-800": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -207,7 +216,8 @@
         "value": "39px",
         "uuid": "bdfae93d-ae49-456b-af54-8620ea976ca8"
       }
-    }
+    },
+    "uuid": "3b3711a6-44fd-44b5-b273-e2c775a15986"
   },
   "font-size-900": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -222,7 +232,8 @@
         "value": "44px",
         "uuid": "5296e771-6d04-4e9a-b1fe-ab22d4dfd92b"
       }
-    }
+    },
+    "uuid": "b164fd8e-2d83-45fc-b636-dba832faad37"
   },
   "font-size-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -237,7 +248,8 @@
         "value": "49px",
         "uuid": "8b158ab0-7e82-4dab-a4d9-84cf7a71fa0a"
       }
-    }
+    },
+    "uuid": "db55c6a2-c72d-4e63-838c-5f30d467bb66"
   },
   "font-size-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -252,7 +264,8 @@
         "value": "55px",
         "uuid": "5eb96c78-c8f6-4e31-9bc8-fa62794ac4db"
       }
-    }
+    },
+    "uuid": "56149ad7-84a7-4067-bad8-c5b143dd0561"
   },
   "font-size-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -267,7 +280,8 @@
         "value": "62px",
         "uuid": "0ab38fb2-0de9-4be0-8967-8241379706be"
       }
-    }
+    },
+    "uuid": "164b0eae-cd17-4e2c-8f30-436c0df7d4c9"
   },
   "font-size-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
@@ -282,7 +296,8 @@
         "value": "70px",
         "uuid": "bd880141-81f6-47fe-a421-01124fe66b67"
       }
-    }
+    },
+    "uuid": "db26e411-a118-4bef-a413-eeb383e85f37"
   },
   "line-height-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/multiplier.json",
@@ -379,7 +394,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "e5bfbd82-a8e6-43dc-b2b6-dc1e171f48aa"
       }
-    }
+    },
+    "uuid": "2094ec97-c8de-46d7-93a4-1f49988bfbf2"
   },
   "heading-sans-serif-font-style": {
     "component": "heading",
@@ -403,7 +419,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "36bea3bb-06b8-4c66-87ad-ffc86be18243"
       }
-    }
+    },
+    "uuid": "2e852baa-60a2-4e7e-9e30-99c14d7e4fef"
   },
   "heading-serif-font-style": {
     "component": "heading",
@@ -427,7 +444,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "21643fcd-b1da-4057-8fb5-e75167c0d89f"
       }
-    }
+    },
+    "uuid": "203b2652-aa62-47f7-b4b5-52e22532de80"
   },
   "heading-cjk-font-style": {
     "component": "heading",
@@ -631,7 +649,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "723c8306-12fb-4cb5-9fd2-3ad40d57bb25"
       }
-    }
+    },
+    "uuid": "445edecf-360c-4c42-aaf2-3b7380678365"
   },
   "heading-sans-serif-emphasized-font-style": {
     "component": "heading",
@@ -655,7 +674,8 @@
         "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "e9b3a7b0-ae46-48be-a143-f26463860d3f"
       }
-    }
+    },
+    "uuid": "aa539366-543c-4cf5-b326-8c6e8a09f846"
   },
   "heading-serif-emphasized-font-style": {
     "component": "heading",

--- a/packages/tokens/tasks/addIds.js
+++ b/packages/tokens/tasks/addIds.js
@@ -19,6 +19,7 @@ console.log(files);
 
 const VALUE = "value";
 const UUID = "uuid";
+const SETS = "sets";
 const uuids = [];
 
 // dumb function to check if something is an object
@@ -46,7 +47,7 @@ function findUUIDs(json) {
 // check for and add uuids
 function addUUIDs(json) {
   // if it is in want of uuid, give it one
-  if (json[VALUE] && !json[UUID]) {
+  if (!json[UUID] && (json[VALUE] || json[SETS])) {
     while (!json[UUID] || uuids.includes(json[UUID])) {
       json[UUID] = crypto.randomUUID(); // https://stackoverflow.com/questions/105034/how-do-i-create-a-guid-uuid#2117523
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1511,6 +1511,7 @@ packages:
         integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==,
       }
     engines: { node: ">=10" }
+    deprecated: This package is no longer supported.
 
   argparse@1.0.10:
     resolution:
@@ -2578,6 +2579,7 @@ packages:
         integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==,
       }
     engines: { node: ">=10" }
+    deprecated: This package is no longer supported.
 
   get-caller-file@2.0.5:
     resolution:
@@ -2642,6 +2644,7 @@ packages:
       {
         integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==,
       }
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-directory@4.0.1:
     resolution:
@@ -2856,6 +2859,7 @@ packages:
       {
         integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==,
       }
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution:
@@ -3702,6 +3706,7 @@ packages:
       {
         integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==,
       }
+    deprecated: This package is no longer supported.
 
   object-assign@4.1.1:
     resolution:
@@ -4210,6 +4215,7 @@ packages:
       {
         integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==,
       }
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@5.0.5:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added UUIDs to the base of tokens with `sets` properties.

## Motivation and Context

@shirlsli requested the UUIDs to make it easier to make comparisons for the updated Token Diff tool. This will be particularly helpful in the cases where a token is converted from a set to a single value or when a token is renamed.

## How Has This Been Tested?

I updated the token schema for the sets tokens so an error is thrown when a UUID is not included.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ x I have added tests to cover my changes.
- [x] All new and existing tests passed.
