### PR TITLE
Created function to detect newly deprecated tokens with some basic tests

### DIFF
--- a/tools/diff-generator/src/index.js
+++ b/tools/diff-generator/src/index.js
@@ -20,11 +20,11 @@ export default function tokenDiff(original, updated) {
   const changes = detailedDiff(original, updated);
   const renamed = checkIfRenamed(original, changes.added); // don't need to check deleted since added will include all renamed schema
   const newTokens = detectNewTokens(renamed, changes.added);
-  // const deprecatedTokens = detectDeprecatedTokens(changes.added);
-  // const deletedTokens = detectDeletedTokens(renamed, changes.deleted);
+  const deprecatedTokens = detectDeprecatedTokens(changes.added);
+  const deletedTokens = detectDeletedTokens(renamed, changes.deleted);
   // formatResult(changes, newTokens, renamed);
   // probably make a json object with renamed, newTokens, etc. and return that?
-  return newTokens;
+  return deprecatedTokens;
 }
 
 /**
@@ -54,7 +54,6 @@ function checkIfRenamed(original, changes) {
  */
 function detectNewTokens(renamed, changes) {
   const addedTokens = changes;
-  console.log(addedTokens);
   if (renamed.length > 0) {
     Object.keys(changes).forEach((token) => {
       renamed.forEach((item) => {
@@ -90,18 +89,26 @@ function detectDeletedTokens(renamed, changes) {
   return deletedTokens;
 }
 
+/**
+ * Detects newly deprecated tokens in the diff
+ * @param {object} changes - the changed token data
+ * @returns {object} deprecatedTokens - a JSON object containing the newly deprecated tokens
+ */
 function detectDeprecatedTokens(changes) {
   const deprecatedTokens = changes;
 
-  Object.keys(changes).forEach((token) => {
-    // console.log("hello?", changes[token].deprecated);
-    if (changes[token].deprecated !== true) {
-      delete deprecatedTokens[token];
+  Object.keys(deprecatedTokens).forEach((token) => {
+    if (token !== undefined) {
+      if (!deprecatedTokens[token].deprecated) {
+        delete deprecatedTokens[token];
+      }
     }
   });
 
   return deprecatedTokens;
 }
+
+// how to check updated values and type?
 
 /**
  * Helper function for looping through due to repetitiveness

--- a/tools/diff-generator/src/lib/deprecated-token-detection.js
+++ b/tools/diff-generator/src/lib/deprecated-token-detection.js
@@ -15,9 +15,8 @@ governing permissions and limitations under the License.
  * @param {object} changes - the changed token data
  * @returns {object} deprecatedTokens - a JSON object containing the newly deprecated tokens
  */
-export default function detectDeprecatedTokens(changes) {
+export default function detectDeprecatedTokens(renamed, changes) {
   const deprecatedTokens = changes;
-
   Object.keys(deprecatedTokens).forEach((token) => {
     if (token !== undefined) {
       if (!deprecatedTokens[token].deprecated) {
@@ -26,5 +25,12 @@ export default function detectDeprecatedTokens(changes) {
     }
   });
 
+  renamed.forEach((name) => {
+    Object.keys(deprecatedTokens).forEach((token) => {
+      if (name["newname"] === token) {
+        delete deprecatedTokens[token];
+      }
+    });
+  });
   return deprecatedTokens;
 }

--- a/tools/diff-generator/src/lib/deprecated-token-detection.js
+++ b/tools/diff-generator/src/lib/deprecated-token-detection.js
@@ -16,15 +16,22 @@ governing permissions and limitations under the License.
  * @returns {object} deprecatedTokens - a JSON object containing the newly deprecated tokens
  */
 export default function detectDeprecatedTokens(renamed, changes) {
-  const deprecatedTokens = changes;
+  const result = {
+    deprecated: {},
+    reverted: {},
+  };
+  const deprecatedTokens = changes.added;
+  const possibleMistakenRevert = changes.deleted;
   Object.keys(deprecatedTokens).forEach((token) => {
-    if (token !== undefined) {
-      if (!deprecatedTokens[token].deprecated) {
-        delete deprecatedTokens[token];
-      }
+    if (token !== undefined && !deprecatedTokens[token].deprecated) {
+      delete deprecatedTokens[token];
     }
   });
-
+  Object.keys(possibleMistakenRevert).forEach((token) => {
+    if (possibleMistakenRevert[token] === undefined) {
+      delete possibleMistakenRevert[token];
+    }
+  });
   renamed.forEach((name) => {
     Object.keys(deprecatedTokens).forEach((token) => {
       if (name["newname"] === token) {
@@ -32,5 +39,11 @@ export default function detectDeprecatedTokens(renamed, changes) {
       }
     });
   });
-  return deprecatedTokens;
+  Object.keys(deprecatedTokens).forEach((token) => {
+    result.deprecated[token] = deprecatedTokens[token];
+  });
+  Object.keys(possibleMistakenRevert).forEach((token) => {
+    result.reverted[token] = possibleMistakenRevert[token];
+  });
+  return result;
 }

--- a/tools/diff-generator/src/lib/renamed-token-detection.js
+++ b/tools/diff-generator/src/lib/renamed-token-detection.js
@@ -27,7 +27,10 @@ export default function checkIfRenamed(original, changes) {
 
   Object.keys(changes).forEach((change) => {
     Object.keys(original).forEach((originalToken) => {
-      if (original[originalToken].uuid === changes[change].uuid) {
+      if (
+        original[originalToken].uuid === changes[change].uuid &&
+        originalToken !== change
+      ) {
         func(renamed, originalToken, change);
       }
     });

--- a/tools/diff-generator/src/lib/renamed-token-detection.js
+++ b/tools/diff-generator/src/lib/renamed-token-detection.js
@@ -16,7 +16,7 @@ governing permissions and limitations under the License.
  * @param {object} changes - the changed token data
  * @returns {object} renamed - an array containing the renamed tokens
  */
-export default function checkIfRenamed(original, changes) {
+export default function detectRenamedTokens(original, changes) {
   const renamed = [];
   const func = (renamed, originalToken, change) => {
     renamed.push({

--- a/tools/diff-generator/test/addedToken.test.js
+++ b/tools/diff-generator/test/addedToken.test.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import test from "ava";
-import checkIfRenamed from "../src/lib/renamed-token-detection.js";
+import detectRenamedTokens from "../src/lib/renamed-token-detection.js";
 import detectNewTokens from "../src/lib/added-token-detection.js";
 import { detailedDiff } from "deep-object-diff";
 import original from "./test-schemas/basic-original-token.json" with { type: "json" };
@@ -78,7 +78,7 @@ const expectedNotRenamed = {
 test("basic test to see if new token was added", (t) => {
   t.deepEqual(
     detectNewTokens(
-      checkIfRenamed(original, detailedDiff(original, updated).added),
+      detectRenamedTokens(original, detailedDiff(original, updated).added),
       detailedDiff(original, updated).added,
     ),
     expectedOneToken,
@@ -88,7 +88,7 @@ test("basic test to see if new token was added", (t) => {
 test("several tokens in each schema test to see if new token was added", (t) => {
   t.deepEqual(
     detectNewTokens(
-      checkIfRenamed(
+      detectRenamedTokens(
         originalSeveral,
         detailedDiff(originalSeveral, updatedSeveral).added,
       ),
@@ -101,7 +101,7 @@ test("several tokens in each schema test to see if new token was added", (t) => 
 test("adding several new and renamed tokens test", (t) => {
   t.deepEqual(
     detectNewTokens(
-      checkIfRenamed(
+      detectRenamedTokens(
         originalEntireSchema,
         detailedDiff(originalEntireSchema, addedRenamedTokens).added,
       ),

--- a/tools/diff-generator/test/deletedToken.test.js
+++ b/tools/diff-generator/test/deletedToken.test.js
@@ -16,7 +16,7 @@ import updated from "./test-schemas/basic-original-token.json" with { type: "jso
 import original from "./test-schemas/new-token.json" with { type: "json" };
 import renamedBasic from "./test-schemas/basic-renamed-token.json" with { type: "json" };
 import { detailedDiff } from "deep-object-diff";
-import checkIfRenamed from "../src/lib/renamed-token-detection.js";
+import detectRenamedTokens from "../src/lib/renamed-token-detection.js";
 
 const expectedOneDeleted = {
   "swatch-border-opacity": undefined,
@@ -27,7 +27,7 @@ const expectedRenamedNotDeleted = {};
 test("basic test to see if token was deleted", (t) => {
   t.deepEqual(
     detectDeletedTokens(
-      checkIfRenamed(original, updated),
+      detectRenamedTokens(original, updated),
       detailedDiff(original, updated).deleted,
     ),
     expectedOneDeleted,
@@ -37,7 +37,7 @@ test("basic test to see if token was deleted", (t) => {
 test("checking if renamed tokens are mistakenly marked as deleted", (t) => {
   t.deepEqual(
     detectDeletedTokens(
-      checkIfRenamed(renamedBasic, updated),
+      detectRenamedTokens(renamedBasic, updated),
       detailedDiff(renamedBasic, updated).deleted,
     ),
     expectedRenamedNotDeleted,
@@ -47,7 +47,7 @@ test("checking if renamed tokens are mistakenly marked as deleted", (t) => {
 test("checking if renamed tokens are mistakenly marked as deleted (same as above but swapped schema)", (t) => {
   t.deepEqual(
     detectDeletedTokens(
-      checkIfRenamed(updated, renamedBasic),
+      detectRenamedTokens(updated, renamedBasic),
       detailedDiff(updated, renamedBasic).deleted,
     ),
     expectedRenamedNotDeleted,

--- a/tools/diff-generator/test/deprecatedToken.test.js
+++ b/tools/diff-generator/test/deprecatedToken.test.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import test from "ava";
 import detectDeprecatedTokens from "../src/lib/deprecated-token-detection.js";
-import checkIfRenamed from "../src/lib/renamed-token-detection.js";
+import detectRenamedTokens from "../src/lib/renamed-token-detection.js";
 import { detailedDiff } from "deep-object-diff";
 import original from "./test-schemas/basic-original-token.json" with { type: "json" };
 import deprecatedToken from "./test-schemas/deprecated-token.json" with { type: "json" };
@@ -22,53 +22,75 @@ import severalRenamedDeprecatedTokens from "./test-schemas/several-renamed-depre
 import severalAddedDeprecatedTokens from "./test-schemas/added-deprecated-token.json" with { type: "json" };
 
 const expected = {
-  "swatch-border-color": {
-    deprecated: true,
-    deprecated_comment: "insert random deprecated comment",
+  deprecated: {
+    "swatch-border-color": {
+      deprecated: true,
+      deprecated_comment: "insert random deprecated comment",
+    },
   },
+  reverted: {},
 };
 
 const expectedSeveralDeprecated = {
-  "swatch-border-opacity": {
-    deprecated: true,
-    deprecated_comment: "insert random deprecated comment",
+  deprecated: {
+    "swatch-border-opacity": {
+      deprecated: true,
+      deprecated_comment: "insert random deprecated comment",
+    },
+    "focus-indicator-color": {
+      deprecated: true,
+      deprecated_comment: "insert random deprecated comment",
+      $schema:
+        "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+      value: "{blue-800}",
+      uuid: "fe914904-a368-414b-a4ac-21c0b0340d05",
+    },
   },
-  "focus-indicator-color": {
-    deprecated: true,
-    deprecated_comment: "insert random deprecated comment",
-    $schema:
-      "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    value: "{blue-800}",
-    uuid: "fe914904-a368-414b-a4ac-21c0b0340d05",
-  },
+  reverted: {},
 };
 
-const expectedRenamedDeprecated = {}; // no new deprecated tokens
+const expectedRenamedDeprecated = {
+  deprecated: {},
+  reverted: {},
+}; // no new deprecated tokens
 
 const expectedAddedDeprecated = {
-  "i-like-mochi": {
-    deprecated: true,
-    deprecated_comment: "insert random deprecated comment",
-    $schema:
-      "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    value: "{blue-800}",
-    uuid: "4567",
+  deprecated: {
+    "i-like-mochi": {
+      deprecated: true,
+      deprecated_comment: "insert random deprecated comment",
+      $schema:
+        "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+      value: "{blue-800}",
+      uuid: "4567",
+    },
+    "i-like-burgers": {
+      deprecated: true,
+      deprecated_comment: "insert random deprecated comment",
+      $schema:
+        "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+      value: "{blue-800}",
+      uuid: "1234",
+    },
   },
-  "i-like-burgers": {
-    deprecated: true,
-    deprecated_comment: "insert random deprecated comment",
-    $schema:
-      "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    value: "{blue-800}",
-    uuid: "1234",
+  reverted: {},
+};
+
+const expectedReverted = {
+  deprecated: {},
+  reverted: {
+    "swatch-border-color": {
+      deprecated: undefined,
+      deprecated_comment: undefined,
+    },
   },
 };
 
 test("basic test to see deprecated token", (t) => {
   t.deepEqual(
     detectDeprecatedTokens(
-      checkIfRenamed(original, deprecatedToken),
-      detailedDiff(original, deprecatedToken).added,
+      detectRenamedTokens(original, deprecatedToken),
+      detailedDiff(original, deprecatedToken),
     ),
     expected,
   );
@@ -77,19 +99,21 @@ test("basic test to see deprecated token", (t) => {
 test("several tokens to see if deprecated token is found", (t) => {
   t.deepEqual(
     detectDeprecatedTokens(
-      checkIfRenamed(severalOriginalTokens, severalDeprecatedTokens),
-      detailedDiff(severalOriginalTokens, severalDeprecatedTokens).added,
+      detectRenamedTokens(severalOriginalTokens, severalDeprecatedTokens),
+      detailedDiff(severalOriginalTokens, severalDeprecatedTokens),
     ),
     expectedSeveralDeprecated,
   );
 });
 
-test("several tokens with with some renamed to see if new deprecated tokens are found", (t) => {
+test("several tokens with some renamed to see if new deprecated tokens are found", (t) => {
   t.deepEqual(
     detectDeprecatedTokens(
-      checkIfRenamed(severalDeprecatedTokens, severalRenamedDeprecatedTokens),
-      detailedDiff(severalDeprecatedTokens, severalRenamedDeprecatedTokens)
-        .added,
+      detectRenamedTokens(
+        severalDeprecatedTokens,
+        severalRenamedDeprecatedTokens,
+      ),
+      detailedDiff(severalDeprecatedTokens, severalRenamedDeprecatedTokens),
     ),
     expectedRenamedDeprecated,
   );
@@ -98,13 +122,22 @@ test("several tokens with with some renamed to see if new deprecated tokens are 
 test("added a token to see if new deprecated tokens are found", (t) => {
   t.deepEqual(
     detectDeprecatedTokens(
-      checkIfRenamed(severalDeprecatedTokens, severalAddedDeprecatedTokens),
-      detailedDiff(severalDeprecatedTokens, severalAddedDeprecatedTokens).added,
+      detectRenamedTokens(
+        severalDeprecatedTokens,
+        severalAddedDeprecatedTokens,
+      ),
+      detailedDiff(severalDeprecatedTokens, severalAddedDeprecatedTokens),
     ),
     expectedAddedDeprecated,
   );
 });
 
-test.skip("reverted a token to not deprecated", (t) => {
-  // not sure if a token can ever by "un-deprecated"
+test("reverted a token to not deprecated", (t) => {
+  t.deepEqual(
+    detectDeprecatedTokens(
+      detectRenamedTokens(deprecatedToken, original),
+      detailedDiff(deprecatedToken, original),
+    ),
+    expectedReverted,
+  );
 });

--- a/tools/diff-generator/test/deprecatedToken.test.js
+++ b/tools/diff-generator/test/deprecatedToken.test.js
@@ -1,0 +1,92 @@
+/*
+Copyright {{ now() | date(format="%Y") }} Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import test from "ava";
+import tokenDiff from "../src/index.js";
+import original from "./test-schemas/basic-original-token.json" with { type: "json" };
+import deprecatedToken from "./test-schemas/deprecated-token.json" with { type: "json" };
+import severalOriginalTokens from "./test-schemas/several-original-tokens.json" with { type: "json" };
+import severalDeprecatedTokens from "./test-schemas/several-deprecated-tokens.json" with { type: "json" };
+import severalRenamedDeprecatedTokens from "./test-schemas/several-renamed-deprecated-tokens.json" with { type: "json" };
+import severalAddedDeprecatedTokens from "./test-schemas/added-deprecated-token.json" with { type: "json" };
+
+const expected = {
+  "swatch-border-color": {
+    deprecated: true,
+    deprecated_comment: "insert random deprecated comment",
+  },
+};
+
+const expectedSeveralDeprecated = {
+  "swatch-border-opacity": {
+    deprecated: true,
+    deprecated_comment: "insert random deprecated comment",
+  },
+  "focus-indicator-color": {
+    deprecated: true,
+    deprecated_comment: "insert random deprecated comment",
+    $schema:
+      "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    value: "{blue-800}",
+    uuid: "fe914904-a368-414b-a4ac-21c0b0340d05",
+  },
+};
+
+const expectedRenamedDeprecated = {}; // no new deprecated tokens
+
+const expectedAddedDeprecated = {
+  "i-like-mochi": {
+    deprecated: true,
+    deprecated_comment: "insert random deprecated comment",
+    $schema:
+      "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    value: "{blue-800}",
+    uuid: "4567",
+  },
+  "i-like-burgers": {
+    deprecated: true,
+    deprecated_comment: "insert random deprecated comment",
+    $schema:
+      "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    value: "{blue-800}",
+    uuid: "1234",
+  },
+};
+
+test("basic test to see deprecated token", (t) => {
+  t.deepEqual(tokenDiff(original, deprecatedToken), expected);
+});
+
+test("several tokens to see if deprecated token is found", (t) => {
+  t.deepEqual(
+    tokenDiff(severalOriginalTokens, severalDeprecatedTokens),
+    expectedSeveralDeprecated,
+  );
+});
+
+test("several tokens with with some renamed to see if new deprecated tokens are found", (t) => {
+  t.deepEqual(
+    tokenDiff(severalDeprecatedTokens, severalRenamedDeprecatedTokens),
+    expectedRenamedDeprecated,
+  );
+});
+
+test("added a token to see if new deprecated tokens are found", (t) => {
+  t.deepEqual(
+    tokenDiff(severalDeprecatedTokens, severalAddedDeprecatedTokens),
+    expectedAddedDeprecated,
+  );
+});
+
+test.skip("reverted a token to not deprecated", (t) => {
+  // not sure if a token can ever by "un-deprecated"
+});

--- a/tools/diff-generator/test/deprecatedToken.test.js
+++ b/tools/diff-generator/test/deprecatedToken.test.js
@@ -11,7 +11,9 @@ governing permissions and limitations under the License.
 */
 
 import test from "ava";
-import tokenDiff from "../src/index.js";
+import detectDeprecatedTokens from "../src/lib/deprecated-token-detection.js";
+import checkIfRenamed from "../src/lib/renamed-token-detection.js";
+import { detailedDiff } from "deep-object-diff";
 import original from "./test-schemas/basic-original-token.json" with { type: "json" };
 import deprecatedToken from "./test-schemas/deprecated-token.json" with { type: "json" };
 import severalOriginalTokens from "./test-schemas/several-original-tokens.json" with { type: "json" };
@@ -63,26 +65,42 @@ const expectedAddedDeprecated = {
 };
 
 test("basic test to see deprecated token", (t) => {
-  t.deepEqual(tokenDiff(original, deprecatedToken), expected);
+  t.deepEqual(
+    detectDeprecatedTokens(
+      checkIfRenamed(original, deprecatedToken),
+      detailedDiff(original, deprecatedToken).added,
+    ),
+    expected,
+  );
 });
 
 test("several tokens to see if deprecated token is found", (t) => {
   t.deepEqual(
-    tokenDiff(severalOriginalTokens, severalDeprecatedTokens),
+    detectDeprecatedTokens(
+      checkIfRenamed(severalOriginalTokens, severalDeprecatedTokens),
+      detailedDiff(severalOriginalTokens, severalDeprecatedTokens).added,
+    ),
     expectedSeveralDeprecated,
   );
 });
 
 test("several tokens with with some renamed to see if new deprecated tokens are found", (t) => {
   t.deepEqual(
-    tokenDiff(severalDeprecatedTokens, severalRenamedDeprecatedTokens),
+    detectDeprecatedTokens(
+      checkIfRenamed(severalDeprecatedTokens, severalRenamedDeprecatedTokens),
+      detailedDiff(severalDeprecatedTokens, severalRenamedDeprecatedTokens)
+        .added,
+    ),
     expectedRenamedDeprecated,
   );
 });
 
 test("added a token to see if new deprecated tokens are found", (t) => {
   t.deepEqual(
-    tokenDiff(severalDeprecatedTokens, severalAddedDeprecatedTokens),
+    detectDeprecatedTokens(
+      checkIfRenamed(severalDeprecatedTokens, severalAddedDeprecatedTokens),
+      detailedDiff(severalDeprecatedTokens, severalAddedDeprecatedTokens).added,
+    ),
     expectedAddedDeprecated,
   );
 });

--- a/tools/diff-generator/test/renamedToken.test.js
+++ b/tools/diff-generator/test/renamedToken.test.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import test from "ava";
-import checkIfRenamed from "../src/lib/renamed-token-detection.js";
+import detectRenamedTokens from "../src/lib/renamed-token-detection.js";
 import { detailedDiff } from "deep-object-diff";
 import original from "./test-schemas/basic-original-token.json" with { type: "json" };
 import updated from "./test-schemas/basic-renamed-token.json" with { type: "json" };
@@ -67,14 +67,14 @@ const expectedSeveralRenamed = [
 
 test("basic test to see if diff catches rename", (t) => {
   t.deepEqual(
-    checkIfRenamed(original, detailedDiff(original, updated).added),
+    detectRenamedTokens(original, detailedDiff(original, updated).added),
     expectedSingleRenamed,
   );
 });
 
 test("several tokens in each schema test to see if diff catches rename", (t) => {
   t.deepEqual(
-    checkIfRenamed(
+    detectRenamedTokens(
       originalTwoOrMore,
       detailedDiff(originalTwoOrMore, updatedTwoOrMore).added,
     ),
@@ -84,7 +84,7 @@ test("several tokens in each schema test to see if diff catches rename", (t) => 
 
 test("existing test to see if diff catches rename", (t) => {
   t.deepEqual(
-    checkIfRenamed(
+    detectRenamedTokens(
       originalEntireSchema,
       detailedDiff(originalEntireSchema, updatedEntireSchema).added,
     ),

--- a/tools/diff-generator/test/test-schemas/added-deprecated-token.json
+++ b/tools/diff-generator/test/test-schemas/added-deprecated-token.json
@@ -1,0 +1,43 @@
+{
+  "swatch-border-color": {
+    "component": "swatch",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{gray-900}",
+    "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48"
+  },
+  "swatch-border-opacity": {
+    "component": "swatch",
+    "deprecated": true,
+    "deprecated_comment": "insert random deprecated comment",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "value": "0.51",
+    "uuid": "0e397a80-cf33-44ed-8b7d-1abaf4426bf5"
+  },
+  "swatch-disabled-icon-border-color": {
+    "component": "swatch",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{black}",
+    "uuid": "c49cd7ae-7657-458b-871a-6b4f28bca535"
+  },
+  "i-like-mochi": {
+    "deprecated": true,
+    "deprecated_comment": "insert random deprecated comment",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{blue-800}",
+    "uuid": "4567"
+  },
+  "focus-indicator-color": {
+    "deprecated": true,
+    "deprecated_comment": "insert random deprecated comment",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{blue-800}",
+    "uuid": "fe914904-a368-414b-a4ac-21c0b0340d05"
+  },
+  "i-like-burgers": {
+    "deprecated": true,
+    "deprecated_comment": "insert random deprecated comment",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{blue-800}",
+    "uuid": "1234"
+  }
+}

--- a/tools/diff-generator/test/test-schemas/deprecated-token.json
+++ b/tools/diff-generator/test/test-schemas/deprecated-token.json
@@ -1,0 +1,10 @@
+{
+  "swatch-border-color": {
+    "component": "swatch",
+    "deprecated": true,
+    "deprecated_comment": "insert random deprecated comment",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{gray-900}",
+    "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48"
+  }
+}

--- a/tools/diff-generator/test/test-schemas/several-deprecated-tokens.json
+++ b/tools/diff-generator/test/test-schemas/several-deprecated-tokens.json
@@ -1,0 +1,29 @@
+{
+  "swatch-border-color": {
+    "component": "swatch",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{gray-900}",
+    "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48"
+  },
+  "swatch-border-opacity": {
+    "component": "swatch",
+    "deprecated": true,
+    "deprecated_comment": "insert random deprecated comment",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "value": "0.51",
+    "uuid": "0e397a80-cf33-44ed-8b7d-1abaf4426bf5"
+  },
+  "swatch-disabled-icon-border-color": {
+    "component": "swatch",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{black}",
+    "uuid": "c49cd7ae-7657-458b-871a-6b4f28bca535"
+  },
+  "focus-indicator-color": {
+    "deprecated": true,
+    "deprecated_comment": "insert random deprecated comment",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{blue-800}",
+    "uuid": "fe914904-a368-414b-a4ac-21c0b0340d05"
+  }
+}

--- a/tools/diff-generator/test/test-schemas/several-renamed-deprecated-tokens.json
+++ b/tools/diff-generator/test/test-schemas/several-renamed-deprecated-tokens.json
@@ -1,0 +1,29 @@
+{
+  "swatch-border-color": {
+    "component": "swatch",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{gray-900}",
+    "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48"
+  },
+  "i-like-matcha-lattes": {
+    "component": "swatch",
+    "deprecated": true,
+    "deprecated_comment": "insert random deprecated comment",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "value": "0.51",
+    "uuid": "0e397a80-cf33-44ed-8b7d-1abaf4426bf5"
+  },
+  "i-like-cookies": {
+    "component": "swatch",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{black}",
+    "uuid": "c49cd7ae-7657-458b-871a-6b4f28bca535"
+  },
+  "focus-indicator-color": {
+    "deprecated": true,
+    "deprecated_comment": "insert random deprecated comment",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{blue-800}",
+    "uuid": "fe914904-a368-414b-a4ac-21c0b0340d05"
+  }
+}

--- a/tools/diff-generator/test/updatedToken.test.js
+++ b/tools/diff-generator/test/updatedToken.test.js
@@ -96,14 +96,3 @@ test.skip("updated more than one property of a token", (t) => {
 test.skip("testing token with updates to its set property", (t) => {
   t.deepEqual(tokenDiff(tokenWithSet, tokenWithUpdatedSet), expectedUpdatedSet);
 });
-
-test.skip("added a token to see if new deprecated tokens are found", (t) => {
-  t.deepEqual(
-    tokenDiff(severalDeprecatedTokens, severalAddedDeprecatedTokens),
-    expectedAddedDeprecated,
-  );
-});
-
-test.skip("reverted a token to not deprecated", (t) => {
-  // not sure if a token can ever by "un-deprecated"
-});


### PR DESCRIPTION
## Description

Created a function to detect newly deprecated tokens with some basic tests to check functionality on mock schema.

## Motivation and Context

Currently, there isn't an ability to see what tokens have been marked deprecated in the diff generator.

## How Has This Been Tested?

- Basic test with one token checking if the diff generator detects that it's been changed to deprecated
- Test with one new deprecated token and one former token marked to deprecated
- Test with same tokens and properties (two are deprecated, two aren't) but renamed to check if the diff generator knows that they aren't newly deprecated; they're old tokens whose names have been changed
- Test with more than one new deprecated token

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
