### PR TITLE
Updated contextual help tokens for S2

### DIFF
--- a/.changeset/flat-parrots-cry.md
+++ b/.changeset/flat-parrots-cry.md
@@ -1,0 +1,37 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+- Fixed token type from Sizing to Font size for contextual-help-body-size and `contextual-help-title-size`
+- Renamed tokens by deprecating previous ones and creating new ones, with font in the token name
+  Updated value of `contextual-help-title-font-size`
+
+Marked the the following tokens in Tokens Studio for deprecation:
+
+- `negative-subdued-background-color-default` ( --> points to `negative-subtle-background-color-default`)
+- `negative-subdued-background-color-hover`
+- `negative-subdued-background-color-down`
+- `negative-subdued-background-color-key-focus`
+
+## Design motivation
+
+- The updated type sorts them correctly in the Tokens Studio data
+- The updated value reflects the latest design for Spectrum 2, using the new title style instead of heading
+
+- The negative-subdued tokens were deprecated because the tag "error" variant has been deprecated and are no longer needed in the system. A new "subtle" token has been added for the in-line alert use case.
+
+## Token diff
+
+_Tokens added (2):_
+
+- `contextual-help-body-font-size`
+- `contextual-help-title-font-size`
+
+_Newly deprecated Tokens (6):_
+
+- `contextual-help-body-size`
+- `contextual-help-title-size`
+- `negative-subdued-background-color-default`
+- `negative-subdued-background-color-hover`
+- `negative-subdued-background-color-down`
+- `negative-subdued-background-color-key-focus`

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -8287,6 +8287,7 @@
     }
   },
   "contextual-help-body-font-size": {
+    "component": "contextual-help",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
     "sets": {
       "desktop": {
@@ -8302,6 +8303,7 @@
     }
   },
   "contextual-help-title-font-size": {
+    "component": "contextual-help",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
     "sets": {
       "desktop": {

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -2599,35 +2599,17 @@
   },
   "contextual-help-title-size": {
     "component": "contextual-help",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
-    "sets": {
-      "desktop": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-        "value": "{heading-size-xs}",
-        "uuid": "5358fd6c-d9a0-4caa-a85e-af82ed82efaf"
-      },
-      "mobile": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-        "value": "{heading-size-xxs}",
-        "uuid": "e91709ce-79e3-4a81-88fa-e124960d4389"
-      }
-    }
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{contextual-help-title-font-size}",
+    "uuid": "5358fd6c-d9a0-4caa-a85e-af82ed82efaf",
+    "deprecated": true
   },
   "contextual-help-body-size": {
     "component": "contextual-help",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
-    "sets": {
-      "desktop": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-        "value": "{body-size-s}",
-        "uuid": "e458fa68-ab9c-4441-a7d5-a02f42df1cae"
-      },
-      "mobile": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-        "value": "{body-size-xs}",
-        "uuid": "c180fa75-254e-4ee1-8b79-31a3d90254cc"
-      }
-    }
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{contextual-help-body-font-size}",
+    "uuid": "e458fa68-ab9c-4441-a7d5-a02f42df1cae",
+    "deprecated": true
   },
   "breadcrumbs-height": {
     "component": "breadcrumbs",
@@ -8301,6 +8283,36 @@
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
         "value": "5px",
         "uuid": "fbf763fe-9e35-4cdc-a5ed-9f90e03d23bd"
+      }
+    }
+  },
+  "contextual-help-body-font-size": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "value": "{body-size-s}",
+        "uuid": "393e9a11-77f6-42a7-973b-34c673ad8afb"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "value": "{body-size-xs}",
+        "uuid": "1d817b1e-7916-4443-b04d-aa232b089f67"
+      }
+    }
+  },
+  "contextual-help-title-font-size": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "value": "{title-size-m}",
+        "uuid": "16ee4dfd-afbe-482b-943e-03e2614037dd"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "value": "{title-size-s}",
+        "uuid": "965f0854-0f3c-4d6e-9e21-54542ecf1a17"
       }
     }
   }

--- a/packages/tokens/src/semantic-color-palette.json
+++ b/packages/tokens/src/semantic-color-palette.json
@@ -401,23 +401,27 @@
   },
   "negative-subdued-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{negative-color-200}",
-    "uuid": "a553db3e-a051-4023-87eb-da6545b983b2"
+    "value": "{negative-subtle-background-color-default}",
+    "uuid": "a553db3e-a051-4023-87eb-da6545b983b2",
+    "deprecated": true
   },
   "negative-subdued-background-color-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{negative-color-300}",
-    "uuid": "9513cf13-8537-443f-81ce-f9d88292ba32"
+    "uuid": "9513cf13-8537-443f-81ce-f9d88292ba32",
+    "deprecated": true
   },
   "negative-subdued-background-color-down": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{negative-color-300}",
-    "uuid": "1eea917c-52e7-4295-b0e1-d33c2e73a137"
+    "uuid": "1eea917c-52e7-4295-b0e1-d33c2e73a137",
+    "deprecated": true
   },
   "negative-subdued-background-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{negative-color-300}",
-    "uuid": "4b6aaf76-e0ab-4be0-81c0-d5f64cacee88"
+    "uuid": "4b6aaf76-e0ab-4be0-81c0-d5f64cacee88",
+    "deprecated": true
   },
   "informative-subtle-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",


### PR DESCRIPTION
Created by Action: https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/9652026396

Contains changes from the following prs:
* [S2 Color - Deprecation of negative-subdued-background tokens](https://github.com/adobe/spectrum-tokens-studio-data/pull/138)
* [Updated contextual help tokens for S2](https://github.com/adobe/spectrum-tokens-studio-data/pull/137)
