### PR TITLE
Updated S2 Swatch and introduced S2 Swatch-group tokens

### DIFF
--- a/.changeset/wet-apricots-tickle.md
+++ b/.changeset/wet-apricots-tickle.md
@@ -1,0 +1,25 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Updated S2 swatch tokens and added swatch-group tokens in S2 Color and S2 Non-color data sets, respectively.
+
+## Design Motivation
+
+Swatch and swatch group components are being formalized as Spectrum 2 components. These tokens define the design data needed for implementation. Changes include updated corner rounding, colors and spacing for spacious density.
+
+For more information, [view Jira ticket](https://jira.corp.adobe.com/browse/SDS-13497).
+
+## Token Diff
+
+_Tokens added (3):_
+
+- `swatch-group-spacing-spacious`
+- `swatch-group-border-opacity`
+- `swatch-group-border-color`
+
+_Tokens values updated (3):_
+
+- `swatch-border-color`: `gray-900` -> `gray-1000`
+- `swatch-border-opacity`: `0.51` -> `0.42`
+- `swatch-disabled-icon-border-opacity`: `0.51` -> `0.42`

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -2,13 +2,13 @@
   "swatch-border-color": {
     "component": "swatch",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{gray-900}",
+    "value": "{gray-1000}",
     "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48"
   },
   "swatch-border-opacity": {
     "component": "swatch",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
-    "value": "0.51",
+    "value": "0.42",
     "uuid": "0e397a80-cf33-44ed-8b7d-1abaf4426bf5"
   },
   "swatch-disabled-icon-border-color": {
@@ -20,7 +20,7 @@
   "swatch-disabled-icon-border-opacity": {
     "component": "swatch",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
-    "value": "0.51",
+    "value": "0.42",
     "uuid": "cdbba3b6-cb51-4fec-88f0-273d4bb59a18"
   },
   "thumbnail-border-color": {
@@ -405,5 +405,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{blue-800}",
     "uuid": "bfd387b8-0ce0-45ff-8d66-fc5de2f4900c"
+  },
+  "swatch-group-border-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{gray-1000}",
+    "uuid": "08b8d06a-5475-47bf-ad2e-9f52ee07345a"
   }
 }

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -407,6 +407,7 @@
     "uuid": "bfd387b8-0ce0-45ff-8d66-fc5de2f4900c"
   },
   "swatch-group-border-color": {
+    "component": "swatch-group",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{gray-1000}",
     "uuid": "08b8d06a-5475-47bf-ad2e-9f52ee07345a"

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -8549,5 +8549,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-100}",
     "uuid": "66540ddb-ec74-487f-8e09-a37b436694b5"
+  },
+  "swatch-group-spacing-spacious": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "b80ef303-eae7-498f-b172-73a098be0f0b"
+  },
+  "swatch-group-border-opacity": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "value": "0.2",
+    "uuid": "19968846-dad0-42eb-b6a8-af65f3a910ff"
   }
 }

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -8551,11 +8551,13 @@
     "uuid": "66540ddb-ec74-487f-8e09-a37b436694b5"
   },
   "swatch-group-spacing-spacious": {
+    "component": "swatch-group",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
     "value": "6px",
     "uuid": "b80ef303-eae7-498f-b172-73a098be0f0b"
   },
   "swatch-group-border-opacity": {
+    "component": "swatch-group",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
     "value": "0.2",
     "uuid": "19968846-dad0-42eb-b6a8-af65f3a910ff"


### PR DESCRIPTION
Created by Action: https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/10089563243
Tokens Studio Data PR: https://github.com/adobe/spectrum-tokens-studio-data/pull/150

## Description

Updated S2 swatch tokens and added swatch-group tokens in S2 Color and S2 Non-color data sets, respectively. 

**_Color_**

- swatch-border-color
- swatch-group-border-color

**_Non-color_**

- swatch-border-opacity
- swatch-disabled-icon-border-opacity
- swatch-group-spacious-spacing
- swatch-group-border-opacity

<!--- Describe your changes in detail, including a list of changes -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Swatch and swatch group components are being formalized as Spectrum 2 components. These tokens define the design data needed for implementation. Changes include updated corner rounding, colors and spacing for spacious density. 