### PR TITLE
Added dragged drop shadow tokens

### DIFF
--- a/.changeset/curly-pants-enjoy.md
+++ b/.changeset/curly-pants-enjoy.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Added dragged drop shadow tokens that point to new 300 global drop shadow tokens
+
+## Design Motivation
+
+These are new foundational drop shadow tokens that represent a higher elevation when items are dragged. The more prominent shadow also brings more visual focus to the dragged item. They will be used in the standard panel "dragged" state, as well as in future component updates, to be determined.
+
+## Token Diff
+
+_Tokens added (8):_
+
+- `drop-shadow-blur-300`
+- `drop-shadow-color-300`
+- `drop-shadow-dragged-blur`
+- `drop-shadow-dragged-color`
+- `drop-shadow-dragged-x`
+- `drop-shadow-dragged-y`
+- `drop-shadow-x-300`
+- `drop-shadow-y-300`

--- a/packages/tokens/src/color-aliases.json
+++ b/packages/tokens/src/color-aliases.json
@@ -1703,6 +1703,21 @@
       }
     }
   },
+  "drop-shadow-color-300": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "sets": {
+      "light": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color.json",
+        "value": "rgba(0, 0, 0, 0.2)",
+        "uuid": "84ced765-054d-44f4-9dbe-5be607f65a16"
+      },
+      "dark": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color.json",
+        "value": "rgba(0, 0, 0, 0.6)",
+        "uuid": "8fd7fa72-67c3-4004-b8b3-af55a4b9cada"
+      }
+    }
+  },
   "drop-shadow-emphasized-default-color": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{drop-shadow-color-100}",
@@ -1757,5 +1772,10 @@
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{transparent-white-900}",
     "uuid": "a1cbc282-1376-48d1-b8bb-92f10aef7c6f"
+  },
+  "drop-shadow-dragged-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{drop-shadow-color-300}",
+    "uuid": "83c30113-68b5-475b-ba46-9179c9ff7e8d"
   }
 }

--- a/packages/tokens/src/layout.json
+++ b/packages/tokens/src/layout.json
@@ -2279,6 +2279,11 @@
     "value": "0px",
     "uuid": "0c76c925-4d29-49a3-b882-e946bd7fe9f1"
   },
+  "drop-shadow-x-300": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "cb6d74fe-cc32-47ff-bf8b-74597643a8a6"
+  },
   "drop-shadow-y-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
     "value": "1px",
@@ -2289,6 +2294,11 @@
     "value": "2px",
     "uuid": "d2d0320a-6984-4b3f-8f5d-ccb88892a26c"
   },
+  "drop-shadow-y-300": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "5d09089b-c0c5-4122-a3be-3e989562acda"
+  },
   "drop-shadow-blur-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
     "value": "6px",
@@ -2298,6 +2308,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
     "value": "8px",
     "uuid": "2b08d425-ecf2-4891-83cd-005a2d5e76ce"
+  },
+  "drop-shadow-blur-300": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "34812e0c-7ccf-49c2-884a-6fecd45f7c5a"
   },
   "drop-shadow-emphasized-default-x": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
@@ -2343,5 +2358,20 @@
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{drop-shadow-blur-200}",
     "uuid": "f3487a86-3aea-4527-8b5c-287c0bddad6c"
+  },
+  "drop-shadow-dragged-x": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{drop-shadow-x-300}",
+    "uuid": "be5c80b4-5769-491b-9550-fcf94f0c762e"
+  },
+  "drop-shadow-dragged-y": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{drop-shadow-y-300}",
+    "uuid": "ff8d4fda-72fa-4256-b2c8-f22a9d3e644f"
+  },
+  "drop-shadow-dragged-blur": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{drop-shadow-blur-300}",
+    "uuid": "f6015252-21fb-48f9-aadb-5ad050e3d590"
   }
 }


### PR DESCRIPTION
Created by Action: https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/10096356349
https://github.com/adobe/spectrum-tokens-studio-data/pull/152

## Description

Added dragged drop shadow tokens that point to new 300 global drop shadow tokens
This update includes x, y, and blur values as well as new color tokens and variables
This also fixes the token type of the non-color drop-shadow sizing tokens

## Motivation and context

These are new foundational drop shadow tokens that represent a higher elevation when items are dragged. The more prominent shadow also brings more visual focus to the dragged item. They will be used in the standard panel "dragged" state, as well as in future component updates, to be determined.