### PR TITLE
Fixed bug in compare card when sharing url of report

### DIFF
--- a/docs/token-diff/src/PageContainer.ts
+++ b/docs/token-diff/src/PageContainer.ts
@@ -19,7 +19,6 @@ import '@spectrum-web-components/theme/src/themes.js';
 import '@spectrum-web-components/overlay/sp-overlay.js';
 import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/divider/sp-divider.js';
-import { property } from 'lit/decorators.js';
 
 export class PageContainer extends LitElement {
   static styles = css`

--- a/tools/diff-generator/src/lib/added-token-detection.js
+++ b/tools/diff-generator/src/lib/added-token-detection.js
@@ -15,6 +15,7 @@ governing permissions and limitations under the License.
  * @param {object} renamed - the token data that were renamed
  * @param {object} deprecatedTokens - the newly deprecated tokens
  * @param {object} changes - the changed token data
+ * @param {object} original - token data to compare against
  * @returns {object} addedTokens - a JSON object containing the added tokens
  */
 


### PR DESCRIPTION
## Description

Implemented sharing via url for the diff generator website. The user is now able to send a link of their report to others and they'll be able to view the report without manually re-selecting the parameters.

## Motivation and Context

My previous approach to handling the passing of parameters into the compare card component was very buggy, so I switched to having the compare card component read in parameters from the url instead of from its parent component. 

## How Has This Been Tested?

Currently there has only been manual testing done by me.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
