### PR TITLE
Updated code tokens for S2

### DIFF
--- a/.changeset/metal-colts-scream.md
+++ b/.changeset/metal-colts-scream.md
@@ -1,0 +1,24 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Updated code tokens for S2
+
+## Design Motivation
+
+These code token updates include some fixes to CJK font-weights to match the Latin font-weights when possible. We added CJK size tokens for consistency with other typography style tokens. Note that the new CJK size tokens currently point to the default code font-size tokens since Source Code Pro handles Latin and CJK sizing comparably.
+
+## Token Diff
+
+_Tokens added (5):_
+
+- `code-cjk-size-l`
+- `code-cjk-size-m`
+- `code-cjk-size-s`
+- `code-cjk-size-xl`
+- `code-cjk-size-xs`
+
+_Token values updated (2):_
+
+- `code-cjk-strong-emphasized-font-weight`
+- `code-cjk-strong-font-weight`

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -8849,5 +8849,30 @@
         "uuid": "c980c4f4-f2c5-4963-873e-de275f3353d1"
       }
     }
+  },
+  "code-cjk-size-xl": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{code-size-xl}",
+    "uuid": "a2e258a0-21f6-44d7-9bfe-0052620e5ac2"
+  },
+  "code-cjk-size-l": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{code-size-l}",
+    "uuid": "15e8593b-1b86-40e0-ae88-fcc587e24373"
+  },
+  "code-cjk-size-m": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{code-size-m}",
+    "uuid": "69436fba-18a7-4a28-b6c5-683a8838917c"
+  },
+  "code-cjk-size-s": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{code-size-s}",
+    "uuid": "80c3d9ab-39d1-4329-a88f-bb84c3afd17f"
+  },
+  "code-cjk-size-xs": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{code-size-xs}",
+    "uuid": "6b577e2a-09c0-42bb-8b94-42034df63036"
   }
 }

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -8851,26 +8851,31 @@
     }
   },
   "code-cjk-size-xl": {
+    "component": "code",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{code-size-xl}",
     "uuid": "a2e258a0-21f6-44d7-9bfe-0052620e5ac2"
   },
   "code-cjk-size-l": {
+    "component": "code",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{code-size-l}",
     "uuid": "15e8593b-1b86-40e0-ae88-fcc587e24373"
   },
   "code-cjk-size-m": {
+    "component": "code",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{code-size-m}",
     "uuid": "69436fba-18a7-4a28-b6c5-683a8838917c"
   },
   "code-cjk-size-s": {
+    "component": "code",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{code-size-s}",
     "uuid": "80c3d9ab-39d1-4329-a88f-bb84c3afd17f"
   },
   "code-cjk-size-xs": {
+    "component": "code",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{code-size-xs}",
     "uuid": "6b577e2a-09c0-42bb-8b94-42034df63036"

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -1537,7 +1537,7 @@
   "code-cjk-strong-font-weight": {
     "component": "code",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{black-font-weight}",
+    "value": "{bold-font-weight}",
     "uuid": "ed73f5fc-5b7a-4414-8f1c-325e7944a9e1"
   },
   "code-cjk-strong-font-style": {
@@ -1585,7 +1585,7 @@
   "code-cjk-strong-emphasized-font-weight": {
     "component": "code",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{black-font-weight}",
+    "value": "{bold-font-weight}",
     "uuid": "8ed5c5e0-ff72-4937-98fd-fd09f1fab288"
   },
   "code-cjk-strong-emphasized-font-style": {


### PR DESCRIPTION
Created by Action: https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/10292339876
Tokens Studio PR: https://github.com/adobe/spectrum-tokens-studio-data/pull/162

## Description

- Updated tokens:
  - code-cjk-strong-font-weight
  - code-cjk-strong-emphasized-font-weight
- Added new tokens:
  - code-cjk-size-xl
  - code-cjk-size-l
  - code-cjk-size-m
  - code-cjk-size-s
  - code-cjk-size-xs
- Reordered existing `code-size-*` tokens to go from XL to XS

## Motivation and context

These code token updates include some fixes to CJK font-weights to match the Latin font-weights when possible. We added CJK size tokens for consistency with other typography style tokens. Note that the new CJK size tokens currently point to the default code font-size tokens since Source Code Pro handles Latin and CJK sizing comparably.
