### PR TITLE
Undeprecate overlay-opacity

### DIFF
--- a/packages/tokens/src/color-aliases.json
+++ b/packages/tokens/src/color-aliases.json
@@ -25,14 +25,12 @@
       "light": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
         "value": "0.4",
-        "uuid": "26b9803c-577f-4a29-badd-dfc459e8b73e",
-        "deprecated": true
+        "uuid": "26b9803c-577f-4a29-badd-dfc459e8b73e"
       },
       "dark": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
         "value": "0.6",
-        "uuid": "31d5b502-6266-4309-8f8a-3892e6e158da",
-        "deprecated": true
+        "uuid": "31d5b502-6266-4309-8f8a-3892e6e158da"
       },
       "wireframe": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`overlay-opacity` is marked as deprecated and seems to be a mistake.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
