### PR TITLE
S1 typography update for CJK improvements

### DIFF
--- a/.changeset/brave-dragons-sparkle.md
+++ b/.changeset/brave-dragons-sparkle.md
@@ -1,0 +1,46 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Token changes for CJK typography improvements.
+
+Updated S1 tokens - typography, foundations
+
+## Design Motivation
+
+The S1 type token changes fix some minor issues with CJK font-sizing, font-weight, and removes the added letter-spacing (since we got feedback this was unnecessary and both latin and CJK characters look too spaced out with the current letter-spacing applied).
+
+## Token Diff
+
+_Tokens added (13):_
+
+- `body-cjk-size-l`
+- `body-cjk-size-m`
+- `body-cjk-size-s`
+- `body-cjk-size-xl`
+- `body-cjk-size-xs`
+- `body-cjk-size-xxl`
+- `body-cjk-size-xxxl`
+- `detail-cjk-size-l`
+- `detail-cjk-size-m`
+- `detail-cjk-size-s`
+- `detail-cjk-size-xl`
+- `font-size-25`
+- `letter-spacing`
+
+_Token values updated (14):_
+
+- `body-cjk-strong-emphasized-font-weight`
+- `body-cjk-strong-font-weight`
+- `cjk-letter-spacing`
+- `detail-cjk-emphasized-font-weight`
+- `detail-cjk-strong-emphasized-font-weight`
+- `detail-cjk-strong-font-weight`
+- `drop-zone-cjk-title-size`
+- `heading-cjk-heavy-font-weight`
+- `heading-cjk-size-s`
+- `heading-cjk-size-xs`
+- `heading-cjk-size-xxl`
+- `heading-cjk-size-xxs`
+- `heading-cjk-size-xxxl`
+- `illustrated-message-cjk-title-size`

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -7971,8 +7971,8 @@
     "uuid": "e2f9f620-b8f0-4fb7-a9b0-e78f13a0ac03"
   },
   "accordion-top-to-text-spacious-small": {
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
     "component": "accordion",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
     "sets": {
       "desktop": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
@@ -7987,77 +7987,68 @@
     },
     "uuid": "bdf7a208-dbfa-4a66-9138-baec261d2908"
   },
-  "letter-spacing": {
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
-    "value": "0em",
-    "uuid": "d8caf3aa-1261-411f-b383-18f87334c117"
-  },
-  "font-size-25": {
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
-    "sets": {
-      "desktop": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/font-size.json",
-        "value": "10px",
-        "uuid": "26ab49ea-7e86-4f0d-812e-ef1ba794c8a8"
-      },
-      "mobile": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/font-size.json",
-        "value": "12px",
-        "uuid": "5946a4e5-8bed-4dd7-aa73-9ebe232f9790"
-      }
-    }
-  },
   "detail-cjk-size-xl": {
+    "component": "detail",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-100}",
     "uuid": "1bbf01a7-c624-452f-a6b6-8486724bc362"
   },
   "detail-cjk-size-l": {
+    "component": "detail",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-75}",
     "uuid": "e9c9bf5a-b7a1-4a53-8335-66697c5bd44f"
   },
   "detail-cjk-size-m": {
+    "component": "detail",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-50}",
     "uuid": "16915081-2765-4553-9e8c-7acb686938cc"
   },
   "detail-cjk-size-s": {
+    "component": "detail",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-25}",
     "uuid": "648162b2-154f-459c-a261-8226bf855714"
   },
   "body-cjk-size-xxxl": {
+    "component": "body",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-500}",
     "uuid": "71a41f9e-73da-4632-8877-7af7acf4db03"
   },
   "body-cjk-size-xxl": {
+    "component": "body",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-400}",
     "uuid": "9aab03eb-c0c1-462c-aa7c-88c93b06f714"
   },
   "body-cjk-size-xl": {
+    "component": "body",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-300}",
     "uuid": "25d65a6e-e8e1-4849-848a-984373fd9cf9"
   },
   "body-cjk-size-l": {
+    "component": "body",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-200}",
     "uuid": "9f0e0ddb-a4d2-416e-a425-8d71527f77b2"
   },
   "body-cjk-size-m": {
+    "component": "body",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-100}",
     "uuid": "7e01bc65-5823-456f-a830-9848a96ad85a"
   },
   "body-cjk-size-s": {
+    "component": "body",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-75}",
     "uuid": "081aa502-e2f1-4bc8-8fb2-a00dcd4236dd"
   },
   "body-cjk-size-xs": {
+    "component": "body",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
     "value": "{font-size-50}",
     "uuid": "ba73926d-2ef4-4d7b-86c2-9044aa1cdf95"

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -7986,5 +7986,80 @@
       }
     },
     "uuid": "bdf7a208-dbfa-4a66-9138-baec261d2908"
+  },
+  "letter-spacing": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
+    "value": "0em",
+    "uuid": "d8caf3aa-1261-411f-b383-18f87334c117"
+  },
+  "font-size-25": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/font-size.json",
+        "value": "10px",
+        "uuid": "26ab49ea-7e86-4f0d-812e-ef1ba794c8a8"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/font-size.json",
+        "value": "12px",
+        "uuid": "5946a4e5-8bed-4dd7-aa73-9ebe232f9790"
+      }
+    }
+  },
+  "detail-cjk-size-xl": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-100}",
+    "uuid": "1bbf01a7-c624-452f-a6b6-8486724bc362"
+  },
+  "detail-cjk-size-l": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-75}",
+    "uuid": "e9c9bf5a-b7a1-4a53-8335-66697c5bd44f"
+  },
+  "detail-cjk-size-m": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-50}",
+    "uuid": "16915081-2765-4553-9e8c-7acb686938cc"
+  },
+  "detail-cjk-size-s": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-25}",
+    "uuid": "648162b2-154f-459c-a261-8226bf855714"
+  },
+  "body-cjk-size-xxxl": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-500}",
+    "uuid": "71a41f9e-73da-4632-8877-7af7acf4db03"
+  },
+  "body-cjk-size-xxl": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-400}",
+    "uuid": "9aab03eb-c0c1-462c-aa7c-88c93b06f714"
+  },
+  "body-cjk-size-xl": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-300}",
+    "uuid": "25d65a6e-e8e1-4849-848a-984373fd9cf9"
+  },
+  "body-cjk-size-l": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-200}",
+    "uuid": "9f0e0ddb-a4d2-416e-a425-8d71527f77b2"
+  },
+  "body-cjk-size-m": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-100}",
+    "uuid": "7e01bc65-5823-456f-a830-9848a96ad85a"
+  },
+  "body-cjk-size-s": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-75}",
+    "uuid": "081aa502-e2f1-4bc8-8fb2-a00dcd4236dd"
+  },
+  "body-cjk-size-xs": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{font-size-50}",
+    "uuid": "ba73926d-2ef4-4d7b-86c2-9044aa1cdf95"
   }
 }

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -59,6 +59,22 @@
     "value": "normal",
     "uuid": "25668698-bf78-46f4-bc6c-8fea068ddb34"
   },
+  "font-size-25": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/font-size.json",
+        "value": "10px",
+        "uuid": "26ab49ea-7e86-4f0d-812e-ef1ba794c8a8"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/font-size.json",
+        "value": "12px",
+        "uuid": "5946a4e5-8bed-4dd7-aa73-9ebe232f9790"
+      }
+    },
+    "uuid": "f0c5ab51-5fc0-417d-a57a-edd12a62847e"
+  },
   "font-size-50": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/scale-set.json",
     "sets": {
@@ -298,6 +314,11 @@
       }
     },
     "uuid": "db26e411-a118-4bef-a413-eeb383e85f37"
+  },
+  "letter-spacing": {
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
+    "value": "0em",
+    "uuid": "d8caf3aa-1261-411f-b383-18f87334c117"
   },
   "line-height-100": {
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/multiplier.json",

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -320,8 +320,8 @@
     "uuid": "c5a5d186-54b3-44a0-b1c6-e9b102871015"
   },
   "cjk-letter-spacing": {
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
-    "value": "0.05em",
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{letter-spacing}",
     "uuid": "12e27721-35f5-4d03-95f3-3fc9e1cf50e4"
   },
   "heading-sans-serif-font-family": {
@@ -480,7 +480,7 @@
   "heading-cjk-heavy-font-weight": {
     "component": "heading",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{black-font-weight}",
+    "value": "{extra-bold-font-weight}",
     "uuid": "73c20d2f-1227-46bc-8548-102358405b0b"
   },
   "heading-cjk-heavy-font-style": {
@@ -890,13 +890,13 @@
   "heading-cjk-size-xxxl": {
     "component": "heading",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{font-size-1300}",
+    "value": "{font-size-1200}",
     "uuid": "5a44e177-2478-4bb0-9212-ba2df64c8b00"
   },
   "heading-cjk-size-xxl": {
     "component": "heading",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{font-size-900}",
+    "value": "{font-size-1000}",
     "uuid": "fbf59302-1ad2-4327-bfde-d638a0ca2429"
   },
   "heading-cjk-size-xl": {
@@ -920,19 +920,19 @@
   "heading-cjk-size-s": {
     "component": "heading",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{font-size-300}",
+    "value": "{font-size-200}",
     "uuid": "c1242a8c-ca10-40d0-8fc4-67bbbce8fc5f"
   },
   "heading-cjk-size-xs": {
     "component": "heading",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{font-size-200}",
+    "value": "{font-size-100}",
     "uuid": "132688a7-917d-44b9-a34f-a7135599b299"
   },
   "heading-cjk-size-xxs": {
     "component": "heading",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{font-size-100}",
+    "value": "{font-size-75}",
     "uuid": "bddd6a96-c280-47ca-8858-20df055e488d"
   },
   "heading-line-height": {
@@ -1046,7 +1046,7 @@
   "body-cjk-strong-font-weight": {
     "component": "body",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{black-font-weight}",
+    "value": "{extra-bold-font-weight}",
     "uuid": "d79de2c4-ca7c-4316-ac44-fee1a66983d7"
   },
   "body-cjk-strong-font-style": {
@@ -1118,7 +1118,7 @@
   "body-cjk-strong-emphasized-font-weight": {
     "component": "body",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{black-font-weight}",
+    "value": "{extra-bold-font-weight}",
     "uuid": "54020791-a975-4e5d-a905-8bffcc9d2d93"
   },
   "body-cjk-strong-emphasized-font-style": {
@@ -1310,7 +1310,7 @@
   "detail-cjk-strong-font-weight": {
     "component": "detail",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{black-font-weight}",
+    "value": "{extra-bold-font-weight}",
     "uuid": "ef2997f3-276c-4662-8644-9514590114f4"
   },
   "detail-cjk-strong-font-style": {
@@ -1382,7 +1382,7 @@
   "detail-cjk-emphasized-font-weight": {
     "component": "detail",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{black-font-weight}",
+    "value": "{extra-bold-font-weight}",
     "uuid": "aa70fa2d-87ee-4e67-b230-85f400ddd7d1"
   },
   "detail-cjk-emphasized-font-style": {
@@ -1454,7 +1454,7 @@
   "detail-cjk-strong-emphasized-font-weight": {
     "component": "detail",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{black-font-weight}",
+    "value": "{extra-bold-font-weight}",
     "uuid": "a7007c07-15a4-4671-bd3b-7406f4b374bb"
   },
   "detail-cjk-strong-emphasized-font-style": {


### PR DESCRIPTION
Created by Action: https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/10686025072

Design Motivation

The S1 type token changes fix some minor issues with CJK font-sizing, font-weight, and removes the added letter-spacing (since we got feedback this was unnecessary and both latin and CJK characters look too spaced out with the current letter-spacing applied)