### PR TITLE
Fix duplicate set values

### DIFF
--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -420,19 +420,9 @@
   },
   "standard-panel-gripper-color-drag": {
     "component": "standard-panel",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
-    "sets": {
-      "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-        "value": "{gray-800}",
-        "uuid": "69e2d0b3-6807-4e46-9f8a-72bf49439f36"
-      },
-      "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-        "value": "{gray-800}",
-        "uuid": "e0533561-893d-4947-a0bb-d29c0bb42a2b"
-      }
-    }
+    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "value": "{gray-800}",
+    "uuid": "69e2d0b3-6807-4e46-9f8a-72bf49439f36"
   },
   "standard-panel-gripper-color": {
     "component": "standard-panel",


### PR DESCRIPTION
`standard-panel-gripper-color-drag` was mistakenly declared as a color-set token with identical values for the `light` and `dark` values.

<!--- Provide a general summary of your changes in the Title above -->

## Description

`standard-panel-gripper-color-drag` was mistakenly set as a color-set token with identical values for the `light` and `dark` sets. The problem doesn't currently exist in the [adobe/spectrum-tokens-studio-data](https://github.com/adobe/spectrum-tokens-studio-data) repo.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
