### PR TITLE
fix: diff-gen - incorrect identification of renamed tokens

### DIFF
--- a/tools/diff-generator/src/lib/renamed-token-detection.js
+++ b/tools/diff-generator/src/lib/renamed-token-detection.js
@@ -22,6 +22,8 @@ export default function detectRenamedTokens(original, added) {
   Object.keys(added).forEach((change) => {
     Object.keys(original).forEach((originalToken) => {
       if (
+        added[change].uuid &&
+        original[originalToken].uuid &&
         original[originalToken].uuid === added[change].uuid &&
         originalToken !== change
       ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

diff-generator incorrectly identifies token renames due to an invalid uuid comparison. Both objects being compared should be first checked for valid uuids before comparing the uuids otherwise there can be a false positive when neither object has a uuid.

## Related Issue

https://jira.corp.adobe.com/browse/DNA-1376

## Motivation and Context

## How Has This Been Tested?

v48 to v49 cli comparison

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
