### PR TITLE
fix: diff-gen - supports token values that are numeric

### DIFF
--- a/tools/diff-generator/src/lib/updated-token-detection.js
+++ b/tools/diff-generator/src/lib/updated-token-detection.js
@@ -155,7 +155,10 @@ function includeOldProperties(
     ) {
       return;
     }
-    if (typeof curTokenLevel[property] === "string") {
+    if (
+      typeof curTokenLevel[property] === "string" ||
+      typeof curTokenLevel[property] === "number"
+    ) {
       const newValue = curTokenLevel[property];
       const path = !properties.includes(".")
         ? property


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

diff-generator explicitly looks for token values of type 'string', but we introduced support for type 'number'. This checks the additional value type so the reporting of the value change is consistent with strings.

## Related Issue

https://jira.corp.adobe.com/browse/DNA-1376

## Motivation and Context

## How Has This Been Tested?

v48 to v49 cli comparison

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
