### PR TITLE
fix: diff-gen - fixes deprecation messages when missing deprecation comment

### DIFF
--- a/.changeset/fresh-cameras-learn.md
+++ b/.changeset/fresh-cameras-learn.md
@@ -1,0 +1,5 @@
+---
+"@adobe/token-diff-generator": minor
+---
+
+minor fixes to diff tool comparisons

--- a/tools/diff-generator/src/lib/cli.js
+++ b/tools/diff-generator/src/lib/cli.js
@@ -157,11 +157,13 @@ const printStyleRenamed = (result, token, log, i) => {
  * @param {object} i - the number of times to indent
  */
 const printStyleDeprecated = (result, token, log, i) => {
+  let comment = result[token]["deprecated_comment"];
   log(
     indent(
       yellow(`"${token}"`) +
-        white(": ") +
-        yellow(`"${result[token]["deprecated_comment"]}"`),
+        (typeof comment === "string" && comment.length
+          ? this.white(": ") + this.yellow(`"${comment}"`)
+          : ""),
       i,
     ),
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

diff-generator muddles the deprecated token reporting as it doesn't handle undefined deprecated comments.

## Related Issue

https://jira.corp.adobe.com/browse/DNA-1377

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

v48 to v49 cli comparison

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
