### PR TITLE
Added `prepare` script to update cli hardcoded version number

### DIFF
--- a/.changeset/forty-moons-train.md
+++ b/.changeset/forty-moons-train.md
@@ -1,0 +1,5 @@
+---
+"@adobe/token-diff-generator": patch
+---
+
+Fix version number in cli using a prepare script in the package.json file

--- a/tools/diff-generator/package.json
+++ b/tools/diff-generator/package.json
@@ -4,7 +4,8 @@
   "description": "Creates diffs for tokens",
   "type": "module",
   "scripts": {
-    "test": "c8 ava"
+    "test": "c8 ava",
+    "prepare": "node update-version.js"
   },
   "repository": {
     "type": "git",

--- a/tools/diff-generator/src/lib/cli.js
+++ b/tools/diff-generator/src/lib/cli.js
@@ -20,19 +20,13 @@ import * as emoji from "node-emoji";
 
 import { Command } from "commander";
 
-import { readFileSync } from "fs";
-
 const yellow = chalk.hex("F3EE7E");
 const red = chalk.hex("F37E7E");
 const green = chalk.hex("7EF383");
 const white = chalk.white;
 
-// Read the content of package.json
-const packageJsonContent = readFileSync("./package.json", "utf8");
-// Parse the JSON data
-const packageInfo = JSON.parse(packageJsonContent);
-// Access the version property
-const version = packageInfo.version;
+/* this is updated by the npm prepare script using update-version.js */
+const version = "1.1.1";
 
 const program = new Command();
 
@@ -40,12 +34,6 @@ program
   .name("tdiff")
   .description("CLI to a Spectrum token diff generator")
   .version(version);
-program
-  .command("version")
-  .description("Returns the current package version number for tdiff")
-  .action(() => {
-    console.log(version);
-  });
 program
   .command("report")
   .description("Generates a diff report for two inputted schema")

--- a/tools/diff-generator/test/cli.test.js
+++ b/tools/diff-generator/test/cli.test.js
@@ -28,7 +28,7 @@ test("cli should return correct version number", async (t) => {
         .expect((result) => {
           t.true(result.stdout.includes(packageJSON.version));
         })
-        .run("./src/lib/cli.js version")
+        .run("./src/lib/cli.js --version")
         .end(resolve);
     } catch (error) {
       reject(error);

--- a/tools/diff-generator/update-version.js
+++ b/tools/diff-generator/update-version.js
@@ -1,0 +1,27 @@
+import { readFile, writeFile } from "fs/promises";
+import { resolve, relative } from "path";
+import * as url from "url";
+
+export const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
+
+const readJson = async (fileName) =>
+  JSON.parse(await readFile(fileName, "utf8"));
+
+const cliFilePath = resolve(__dirname, "src", "lib", "cli.js");
+
+const [packageFile, cliFile] = await Promise.all([
+  readJson(resolve(__dirname, "package.json")),
+  readFile(cliFilePath, "utf8"),
+]);
+
+await writeFile(
+  cliFilePath,
+  cliFile.replace(
+    /const version = \"([^\"]*)\";/,
+    `const version = "${packageFile.version}";`,
+  ),
+);
+
+console.log(
+  `Version updated in CLI file ${relative(__dirname, cliFilePath)} to "${packageFile.version}"`,
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It's tricky to read in the package json file version number for the cli to return for `tdiff --version`. I added a prepare script to the package json that will find and replace the hardcoded version number in the `src/lib/cli.js` file.

## How Has This Been Tested?

Locally only. We won't be able to know if it's working for sure without publishing the package.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
