### PR TITLE
fix: diff-gen - deprecation in sets not being detected

### DIFF
--- a/tools/diff-generator/src/lib/deprecated-token-detection.js
+++ b/tools/diff-generator/src/lib/deprecated-token-detection.js
@@ -26,7 +26,7 @@ export default function detectDeprecatedTokens(renamedTokens, changes) {
   const possibleMistakenRevert = { ...changes.deleted };
   Object.keys(changes.added).forEach((token) => {
     if (
-      (token !== undefined && !deprecatedTokens[token].deprecated) ||
+      (token !== undefined && !isDeprecated(deprecatedTokens[token])) ||
       renamedTokens[token] !== undefined
     ) {
       delete deprecatedTokens[token];
@@ -41,4 +41,20 @@ export default function detectDeprecatedTokens(renamedTokens, changes) {
   result.deprecated = deprecatedTokens;
   result.reverted = possibleMistakenRevert;
   return result;
+}
+
+function isDeprecated(tokenObj) {
+  if (typeof tokenObj !== "object") {
+    return false;
+  } else if (tokenObj.deprecated) {
+    return true;
+  } else {
+    let result = false;
+
+    Object.keys(tokenObj).forEach((property) => {
+      result = result || isDeprecated(tokenObj[property]);
+    });
+
+    return result;
+  }
 }

--- a/tools/diff-generator/src/lib/deprecated-token-detection.js
+++ b/tools/diff-generator/src/lib/deprecated-token-detection.js
@@ -34,8 +34,10 @@ export default function detectDeprecatedTokens(renamedTokens, changes) {
   });
   Object.keys(changes.deleted).forEach((token) => {
     const t = possibleMistakenRevert[token]; // a token marked as deleted
-    if (t === undefined || (typeof t !== "string" && !("deprecated" in t))) {
+    if (t === undefined || !wasUndeprecated(t)) {
       delete possibleMistakenRevert[token];
+    } else {
+      delete changes.deleted[token];
     }
   });
   result.deprecated = deprecatedTokens;
@@ -53,6 +55,22 @@ function isDeprecated(tokenObj) {
 
     Object.keys(tokenObj).forEach((property) => {
       result = result || isDeprecated(tokenObj[property]);
+    });
+
+    return result;
+  }
+}
+
+function wasUndeprecated(tokenObj) {
+  if (typeof tokenObj !== "object") {
+    return false;
+  } else if ("deprecated" in tokenObj && tokenObj.deprecated === undefined) {
+    return true;
+  } else {
+    let result = false;
+
+    Object.keys(tokenObj).forEach((property) => {
+      result = result || wasUndeprecated(tokenObj[property]);
     });
 
     return result;

--- a/tools/diff-generator/test/addedToken.test.js
+++ b/tools/diff-generator/test/addedToken.test.js
@@ -167,9 +167,6 @@ const expectedSeveralAddedSetTokens = {
         $schema:
           "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
         value: "{gray-800}",
-        deprecated: true,
-        deprecated_comment:
-          "Express will merge with Spectrum with the release of Spectrum 2.",
         uuid: "60caae29-d389-421e-a574-b26bcaeed3bf",
       },
     },

--- a/tools/diff-generator/test/test-schemas/added-set-tokens-out-of-order.json
+++ b/tools/diff-generator/test/test-schemas/added-set-tokens-out-of-order.json
@@ -78,8 +78,6 @@
       "express": {
         "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
         "value": "{gray-800}",
-        "deprecated": true,
-        "deprecated_comment": "Express will merge with Spectrum with the release of Spectrum 2.",
         "uuid": "60caae29-d389-421e-a574-b26bcaeed3bf"
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes to token deprecation were not being detected when the deprecation was being done in sets, rather than at the root. Also true for un-deprecating tokens.

## Related Issue

https://jira.corp.adobe.com/browse/DNA-1379

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

v47 to v48 cli comparison

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
