### PR TITLE
fix takeover dialog dimensions types

### DIFF
--- a/.changeset/three-buttons-hunt.md
+++ b/.changeset/three-buttons-hunt.md
@@ -1,0 +1,12 @@
+---
+"@adobe/spectrum-tokens": patch
+---
+
+Change takeover dialog dimensions to use percentages which were previously converted to ems by mistake.
+
+## Token Diff
+
+**Updated Tokens (2):**
+
+- `takeover-dialog-height`: `1.00em` -> `1.00%`
+- `takeover-dialog-width`: `1.00em` -> `1.00%`

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -10142,13 +10142,13 @@
   "takeover-dialog-height": {
     "component": "takeover-dialog",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
-    "value": "1.00em",
+    "value": "1.00%",
     "uuid": "be327284-79fe-40b7-b996-8ad176d40d8e"
   },
   "takeover-dialog-width": {
     "component": "takeover-dialog",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/dimension.json",
-    "value": "1.00em",
+    "value": "100%",
     "uuid": "bb70e39d-c686-4cd2-a991-6b51fa16d9df"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change takeover dialog dimensions to use percentages which were previously converted to ems by mistake.

## Token Diff

**Updated Tokens (2):**

- `takeover-dialog-height`: `1.00em` -> `1.00%`
- `takeover-dialog-width`: `1.00em` -> `1.00%`
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
