### PR TITLE
fix(deps): missing glob dependency

### DIFF
--- a/.changeset/rare-zebras-confess.md
+++ b/.changeset/rare-zebras-confess.md
@@ -1,0 +1,12 @@
+---
+"@adobe/spectrum-component-api-schemas": patch
+"@adobe/spectrum-tokens": patch
+"s2-tokens-viewer": patch
+"site": patch
+"@adobe/token-diff-generator": patch
+"token-csv-generator": patch
+"token-manifest-builder": patch
+"transform-tokens-json": patch
+---
+
+Fixed missing glob dependency file in published packages.

--- a/docs/s2-tokens-viewer/tokens/package.json
+++ b/docs/s2-tokens-viewer/tokens/package.json
@@ -28,6 +28,7 @@
     "ajv-formats": "^3.0.1",
     "deep-object-diff": "^1.1.9",
     "find-duplicated-property-keys": "^1.2.9",
+    "glob": "^11.0.2",
     "style-dictionary": "^3.9.2",
     "style-dictionary-sets": "^2.3.0",
     "tar": "^7.4.3",

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -16,6 +16,7 @@
     "@spectrum-css/typography": "^6.1.3",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
+    "glob": "^11.0.2",
     "next": "^14.2.15",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/component-schemas/package.json
+++ b/packages/component-schemas/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/adobe/spectrum-tokens/tree/main/packages/component-schemas#readme",
   "license": "Apache-2.0",
   "dependencies": {
-    "glob": "^10.3.12"
+    "glob": "^11.0.2"
   },
   "devDependencies": {
     "ajv": "^8.12.0",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -28,6 +28,7 @@
     "ajv-formats": "^3.0.1",
     "deep-object-diff": "^1.1.9",
     "find-duplicated-property-keys": "^1.2.9",
+    "glob": "^11.0.2",
     "style-dictionary": "^3.9.2",
     "style-dictionary-sets": "^2.3.0",
     "tar": "^7.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.3
       next:
         specifier: ^14.2.15
         version: 14.2.30(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -214,8 +217,8 @@ importers:
   packages/component-schemas:
     dependencies:
       glob:
-        specifier: ^10.3.12
-        version: 10.4.5
+        specifier: ^11.0.2
+        version: 11.0.3
     devDependencies:
       ajv:
         specifier: ^8.12.0
@@ -241,6 +244,9 @@ importers:
       find-duplicated-property-keys:
         specifier: ^1.2.9
         version: 1.2.9
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.3
       style-dictionary:
         specifier: ^3.9.2
         version: 3.9.2
@@ -265,6 +271,9 @@ importers:
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.3
       handlebars:
         specifier: ^4.7.8
         version: 4.7.8
@@ -293,14 +302,24 @@ importers:
       "@adobe/spectrum-tokens":
         specifier: workspace:*
         version: link:../../packages/tokens
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.3
       jsonpath-plus:
         specifier: ^8.1.0
         version: 8.1.0
 
-  tools/token-manifest-builder: {}
+  tools/token-manifest-builder:
+    dependencies:
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.3
 
   tools/transform-tokens-json:
     dependencies:
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.3
       jsonpath-plus:
         specifier: ^8.1.0
         version: 8.1.0

--- a/tools/diff-generator/package.json
+++ b/tools/diff-generator/package.json
@@ -75,6 +75,7 @@
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
     "deep-object-diff": "^1.1.9",
+    "glob": "^11.0.2",
     "handlebars": "^4.7.8",
     "node-emoji": "^2.2.0"
   },

--- a/tools/token-csv-generator/package.json
+++ b/tools/token-csv-generator/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/adobe/spectrum-tokens#readme",
   "dependencies": {
     "@adobe/spectrum-tokens": "workspace:*",
+    "glob": "^11.0.2",
     "jsonpath-plus": "^8.1.0"
   }
 }

--- a/tools/token-manifest-builder/package.json
+++ b/tools/token-manifest-builder/package.json
@@ -14,5 +14,8 @@
   "bugs": {
     "url": "https://github.com/adobe/spectrum-tokens/issues"
   },
-  "homepage": "https://github.com/adobe/spectrum-tokens#readme"
+  "homepage": "https://github.com/adobe/spectrum-tokens#readme",
+  "dependencies": {
+    "glob": "^11.0.2"
+  }
 }

--- a/tools/transform-tokens-json/package.json
+++ b/tools/transform-tokens-json/package.json
@@ -16,6 +16,7 @@
   },
   "homepage": "https://github.com/adobe/spectrum-tokens#readme",
   "dependencies": {
+    "glob": "^11.0.2",
     "jsonpath-plus": "^8.1.0"
   }
 }


### PR DESCRIPTION
## Description

When attempting to upgrade the version of the token diff utility, we received the following warning:

```
file:///Users/cassondrar/Projects/spectrum-css/node_modules/@adobe/token-diff-generator/src/lib/file-import.js:15
import { glob } from "glob";
         ^^^^
SyntaxError: Named export 'glob' not found. The requested module 'glob' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'glob';
const { glob } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:175:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:258:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:540:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```

As I was adding this dependency to the project, I noticed a few other packages that benefit from an explicit dependency on glob as well (please let me know if that is out-of-scope).

## How Has This Been Tested?

- [ ] Expect installs of the individual packages updated no longer throws a warning on the missing globs requirement.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
