### PR TITLE
feat: rename repository from spectrum-tokens to spectrum-design-data

### DIFF
--- a/.changeset/rename-repository.md
+++ b/.changeset/rename-repository.md
@@ -1,0 +1,16 @@
+---
+---
+
+Repository has been renamed from `spectrum-tokens` to `spectrum-design-data` to better reflect that this monorepo contains more than just design tokens. All GitHub repository URLs and documentation have been updated to reference the new repository location at `github.com/adobe/spectrum-design-data`.
+
+**Important:** NPM package names remain unchanged (`@adobe/spectrum-tokens`, `@adobe/spectrum-component-api-schemas`) to avoid breaking existing consumers.
+
+The following files were updated:
+
+- All `package.json` files with repository URLs
+- Main `README.md` with new repository references
+- Documentation in `docs/visualizer/README.md`
+- Schema URLs in token files to reference the new hosted location
+- Test files with schema references
+
+Note: Historical changelog entries that reference the old repository name in commit and PR URLs are intentionally preserved for historical accuracy.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-Note: for [Spectrum 2](https://s2.spectrum.adobe.com/) token data has been graduated to the `main` branch. If you need access to the S1 data, use the [`s1-legacy` branch](https://github.com/adobe/spectrum-tokens/tree/s1-legacy) and `v12.x.x` packages on [NPM](https://www.npmjs.com/package/@adobe/spectrum-tokens?activeTab=versions).
+Note: for [Spectrum 2](https://s2.spectrum.adobe.com/) token data has been graduated to the `main` branch. If you need access to the S1 data, use the [`s1-legacy` branch](https://github.com/adobe/spectrum-design-data/tree/s1-legacy) and `v12.x.x` packages on [NPM](https://www.npmjs.com/package/@adobe/spectrum-tokens?activeTab=versions).
 
-The [Spectrum token visualizer](https://opensource.adobe.com/spectrum-tokens/visualizer/) shows the token data for S1. For Spectrum 2 data, use [opensource.adobe.com/spectrum-tokens/s2-visualizer/](https://opensource.adobe.com/spectrum-tokens/s2-visualizer/).
+The [Spectrum token visualizer](https://opensource.adobe.com/spectrum-design-data/visualizer/) shows the token data for S1. For Spectrum 2 data, use [opensource.adobe.com/spectrum-design-data/s2-visualizer/](https://opensource.adobe.com/spectrum-design-data/s2-visualizer/).
 
-# Spectrum Tokens Monorepo
+# Spectrum Design Data Monorepo
 
 This repo uses:
 
@@ -16,8 +16,8 @@ This repo uses:
 Packages in this monorepo:
 
 - [Spectrum Tokens](packages/tokens/) design tokens for Spectrum, Adobe's design system.
-- [Spectrum Token Visualizer Tool](docs/visualizer/) a visualizer for inspecting tokens. Published as a [static site](https://opensource.adobe.com/spectrum-tokens/visualizer/), not an NPM package.
-- [Spectrum Token Visualizer Tool S2](docs/s2-visualizer/) a version of the visualizer that shows the Spectrum 2 data. Published as a [static site](https://opensource.adobe.com/spectrum-tokens/s2-visualizer/).
+- [Spectrum Token Visualizer Tool](docs/visualizer/) a visualizer for inspecting tokens. Published as a [static site](https://opensource.adobe.com/spectrum-design-data/visualizer/), not an NPM package.
+- [Spectrum Token Visualizer Tool S2](docs/s2-visualizer/) a version of the visualizer that shows the Spectrum 2 data. Published as a [static site](https://opensource.adobe.com/spectrum-design-data/s2-visualizer/).
 - [Spectrum Tokens Docs](docs/site/) a static site to show the component options API and other token data.
 - [Spectrum Token Diff Generator](tools/diff-generator/) a library and cli tool that reports changes made between two schema/releases/branches.
 

--- a/docs/visualizer/README.md
+++ b/docs/visualizer/README.md
@@ -2,7 +2,7 @@
 
 Current url of deployed static site: [https://opensource.adobe.com/spectrum-tokens/visualizer/](https://opensource.adobe.com/spectrum-tokens/visualizer/)
 
-<img width="1491" alt="Screenshot 2023-02-28 at 2 40 02 PM" src="https://github.com/adobe/spectrum-tokens/assets/125516/3c57f2de-c42e-41a5-abed-e5da294339f0">
+<img width="1491" alt="Screenshot 2023-02-28 at 2 40 02 PM" src="https://github.com/adobe/spectrum-design-data/assets/125516/3c57f2de-c42e-41a5-abed-e5da294339f0">
 
 ## Setup for local development
 
@@ -63,9 +63,9 @@ git push
 
 ## What is this prototype? How does it work?
 
-The Spectrum Tokens source-of-truth is persisted in this public GitHub repo: https://github.com/adobe/spectrum-tokens
+The Spectrum Tokens source-of-truth is persisted in this public GitHub repo: https://github.com/adobe/spectrum-design-data
 
-Within that repository, the tokens are stored in a series of JSON files: https://github.com/adobe/spectrum-tokens/tree/beta/src
+Within that repository, the tokens are stored in a series of JSON files: https://github.com/adobe/spectrum-design-data/tree/beta/src
 
 This json data structure models a directed graph of conditional relationships between tokens, meant to represent the dynamic value assignments that Spectrum clients have access to when using particular filter configurations, such as 'Spectrum/Light/Desktop' or 'Express/Darkest/Mobile'.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/adobe/spectrum-tokens.git"
+    "url": "git+https://github.com/adobe/spectrum-design-data.git"
   },
   "author": "Garth Braithwaite <garthdb@gmail.com> (http://garthdb.com/)",
   "contributors": [
@@ -19,9 +19,9 @@
   ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/adobe/spectrum-tokens/issues"
+    "url": "https://github.com/adobe/spectrum-design-data/issues"
   },
-  "homepage": "https://github.com/adobe/spectrum-tokens#readme",
+  "homepage": "https://github.com/adobe/spectrum-design-data#readme",
   "devDependencies": {
     "@action-validator/core": "^0.6.0",
     "@changesets/changelog-github": "^0.5.1",

--- a/packages/component-schemas/package.json
+++ b/packages/component-schemas/package.json
@@ -7,16 +7,16 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/adobe/spectrum-tokens.git"
+    "url": "git+https://github.com/adobe/spectrum-design-data.git"
   },
   "author": "Garth Braithwaite <garthdb@gmail.com> (https://garthdb.com/)",
   "bugs": {
-    "url": "https://github.com/adobe/spectrum-tokens/issues"
+    "url": "https://github.com/adobe/spectrum-design-data/issues"
   },
   "publishConfig": {
     "provenance": true
   },
-  "homepage": "https://github.com/adobe/spectrum-tokens/tree/main/packages/component-schemas#readme",
+  "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/packages/component-schemas#readme",
   "license": "Apache-2.0",
   "dependencies": {
     "glob": "^10.3.12"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -8,7 +8,7 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/adobe/spectrum-tokens.git"
+    "url": "git+https://github.com/adobe/spectrum-design-data.git"
   },
   "author": "Garth Braithwaite <garthdb@gmail.com> (http://garthdb.com/)",
   "contributors": [
@@ -16,12 +16,12 @@
   ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/adobe/spectrum-tokens/issues"
+    "url": "https://github.com/adobe/spectrum-design-data/issues"
   },
   "publishConfig": {
     "provenance": true
   },
-  "homepage": "https://github.com/adobe/spectrum-tokens/tree/main/packages/tokens#readme",
+  "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/packages/tokens#readme",
   "devDependencies": {
     "@adobe/token-diff-generator": "workspace:*",
     "ajv": "^8.17.1",

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -1,68 +1,68 @@
 {
   "swatch-border-color": {
     "component": "swatch",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-1000}",
     "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48"
   },
   "swatch-border-opacity": {
     "component": "swatch",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.42",
     "uuid": "0e397a80-cf33-44ed-8b7d-1abaf4426bf5"
   },
   "swatch-disabled-icon-border-color": {
     "component": "swatch",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{black}",
     "uuid": "c49cd7ae-7657-458b-871a-6b4f28bca535"
   },
   "swatch-disabled-icon-border-opacity": {
     "component": "swatch",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.42",
     "uuid": "cdbba3b6-cb51-4fec-88f0-273d4bb59a18"
   },
   "thumbnail-border-color": {
     "component": "thumbnail",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-800}",
     "uuid": "5bd226f1-0a6b-42bc-80af-4a9dde99e9e9"
   },
   "thumbnail-border-opacity": {
     "component": "thumbnail",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
     "uuid": "58bd04e9-5b85-44d8-8474-96e157701070"
   },
   "thumbnail-opacity-disabled": {
     "component": "thumbnail",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{opacity-disabled}",
     "uuid": "92418bcd-5f0f-4f26-9a96-51f8c9e871bf"
   },
   "opacity-checkerboard-square-light": {
     "component": "opacity-checkerboard",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{white}",
     "uuid": "c7e50676-3f61-49c3-a35f-2532fdb02360"
   },
   "opacity-checkerboard-square-dark": {
     "component": "opacity-checkerboard",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-200}",
         "uuid": "84a7cd5e-bb2b-4bb5-bb5f-f5839ae3a761"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-800}",
         "uuid": "f783b8cb-d31f-46c2-b550-990639752510"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-200}",
         "uuid": "35fcf7b1-7140-4522-8410-48547aaf6fd6"
       }
@@ -70,37 +70,37 @@
   },
   "avatar-opacity-disabled": {
     "component": "avatar",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{opacity-disabled}",
     "uuid": "84d25d1b-f9e4-4a9e-8cd0-92367ff00637"
   },
   "color-area-border-color": {
     "component": "color-area",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-1000}",
     "uuid": "70fc4674-0f09-48f5-8850-48b4b38c2f01"
   },
   "color-area-border-opacity": {
     "component": "color-area",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
     "uuid": "fba1851e-0056-4cdf-938d-6d61550bbe3c"
   },
   "color-slider-border-color": {
     "component": "color-slider",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-1000}",
     "uuid": "0c85e7fa-f950-436c-a68a-dd7fb8dfac9e"
   },
   "color-slider-border-opacity": {
     "component": "color-slider",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
     "uuid": "8271b69e-6542-4b17-b0f0-72567e16c41b"
   },
   "color-loupe-drop-shadow-color": {
     "component": "color-loupe",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{drop-shadow-elevated-color}",
     "uuid": "918b8089-d89f-45d2-8c9c-f3f13f81b0b9",
     "deprecated": true,
@@ -108,46 +108,46 @@
   },
   "color-loupe-drop-shadow-y": {
     "component": "color-loupe",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{drop-shadow-elevated-y}",
     "uuid": "c9af5d60-11b1-4fc3-972e-6a607120657b",
     "deprecated": true
   },
   "color-loupe-drop-shadow-blur": {
     "component": "color-loupe",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{drop-shadow-elevated-blur}",
     "uuid": "86caa027-9e9e-4a5f-aa38-058f0a96bc9d",
     "deprecated": true
   },
   "color-loupe-inner-border": {
     "component": "color-loupe",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{transparent-black-200}",
     "uuid": "d2c4cb48-8a90-461d-95bc-d882ba01472b"
   },
   "color-loupe-outer-border": {
     "component": "color-loupe",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{white}",
     "uuid": "4e1d1cc5-736e-4e82-9054-5c1a74ac1aca"
   },
   "card-selection-background-color": {
     "component": "card",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{transparent-white-600}",
         "uuid": "622c6e86-dea6-416d-9f13-bb6ef112d3cb"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{transparent-black-600}",
         "uuid": "81c0608b-c977-490e-b8d7-830d0676fdad"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{transparent-black-600}",
         "uuid": "5dd9406f-9b36-43f1-8b35-b1bb7f2a4c8d"
       }
@@ -155,61 +155,61 @@
   },
   "card-selection-background-color-opacity": {
     "component": "card",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.95",
     "uuid": "ac039445-0bf8-4821-b02e-e7e06a416576"
   },
   "drop-zone-background-color": {
     "component": "drop-zone",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{accent-visual-color}",
     "uuid": "866f3613-c12f-4475-87b1-ad86ef2ce153"
   },
   "drop-zone-background-color-opacity": {
     "component": "drop-zone",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
     "uuid": "ee5ed78b-230c-4b37-9d76-1787a975bb63"
   },
   "drop-zone-background-color-opacity-filled": {
     "component": "drop-zone",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.3",
     "uuid": "ca70550a-b11a-438f-9c70-ff1eeba532cc"
   },
   "coach-mark-pagination-color": {
     "component": "coach-mark",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-600}",
     "uuid": "f8cefe70-db2c-489e-bbbe-964050e96ab6"
   },
   "color-handle-inner-border-color": {
     "component": "color-handle",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{black}",
     "uuid": "0c93f310-d7c6-474b-8f07-0e8e76e2756e"
   },
   "color-handle-inner-border-opacity": {
     "component": "color-handle",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.42",
     "uuid": "72b473c6-ec9b-4830-a0f8-48b80070e7b8"
   },
   "color-handle-outer-border-color": {
     "component": "color-handle",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{black}",
     "uuid": "e4733356-090e-4bb7-b32d-ab9df30fb785"
   },
   "color-handle-outer-border-opacity": {
     "component": "color-handle",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{color-handle-inner-border-opacity}",
     "uuid": "0a0eff89-7e7d-4b7f-bcfa-a85e33e5798a"
   },
   "color-handle-drop-shadow-color": {
     "component": "color-handle",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "deprecated": true,
     "deprecated_comment": "Express does not need a separate design for Color loupe and Color handle components",
     "value": "{drop-shadow-color}",
@@ -217,13 +217,13 @@
   },
   "floating-action-button-drop-shadow-color": {
     "component": "floating-action-button",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{transparent-black-300}",
     "uuid": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0"
   },
   "floating-action-button-shadow-color": {
     "component": "floating-action-button",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{floating-action-button-drop-shadow-color}",
     "uuid": "f843b1b7-4b2f-496e-a679-b0372e49d575",
     "deprecated": true,
@@ -231,74 +231,74 @@
   },
   "table-row-hover-color": {
     "component": "table",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-900}",
     "uuid": "44aedb76-5483-4ac3-a6f5-8cf71c2bd376"
   },
   "table-row-hover-opacity": {
     "component": "table",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.07",
     "uuid": "e287d553-3712-4d6e-98f0-6075107e85fe"
   },
   "table-selected-row-background-color": {
     "component": "table",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{informative-background-color-default}",
     "uuid": "b7537f50-bd49-44b6-a171-19943d443d24"
   },
   "table-selected-row-background-opacity": {
     "component": "table",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
     "uuid": "61b3aa04-0e7e-44b8-a4c8-8442a4ebf549"
   },
   "table-selected-row-background-color-non-emphasized": {
     "component": "table",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{neutral-background-color-selected-default}",
     "uuid": "8578067a-6ce0-4059-84ad-4688c71df156"
   },
   "table-selected-row-background-opacity-non-emphasized": {
     "component": "table",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
     "uuid": "1ef41e27-3dea-4589-ad7a-140a03a77384"
   },
   "table-row-down-opacity": {
     "component": "table",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
     "uuid": "75ae742c-e96e-494f-9880-746bb2849575"
   },
   "table-selected-row-background-opacity-hover": {
     "component": "table",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.15",
     "uuid": "ce2851bc-8ae1-4b27-8cd6-f191c9cd7fe9"
   },
   "table-selected-row-background-opacity-non-emphasized-hover": {
     "component": "table",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.15",
     "uuid": "6a093ea1-f07e-4673-b52f-5b28a2e080d0"
   },
   "menu-item-background-color-default": {
     "component": "menu-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "f4d97d6a-c1f3-4ef5-b7e5-8fbee1365a83"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-200}",
         "uuid": "9b9e8b32-46b8-470d-85b9-352c00e90138"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "ae0fb15e-c8a2-42c4-b973-0fb523003b79"
       }
@@ -306,20 +306,20 @@
   },
   "menu-item-background-color-hover": {
     "component": "menu-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "857e82a6-537e-4534-9084-353c5401f567"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-200}",
         "uuid": "f68ff159-e886-4519-b95e-e93879a2f535"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "1329d684-6ac9-4f46-9bbc-046e2de5276e"
       }
@@ -327,20 +327,20 @@
   },
   "menu-item-background-color-down": {
     "component": "menu-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "d609bd79-ab48-4a7a-95b1-da5a88ac5338"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-200}",
         "uuid": "7ccdd9e8-3677-4de8-b9df-19efa80d88c0"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "e31108a0-1b8a-4d5e-b579-592a01619bd0"
       }
@@ -348,20 +348,20 @@
   },
   "menu-item-background-color-keyboard-focus": {
     "component": "menu-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "dd044387-57b9-4867-90fa-b3c4c4a62e5c"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-200}",
         "uuid": "ae9dc785-2406-407e-ab47-d42d6fbf65f6"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "e9b046ee-408e-4781-a2cd-1d321bde4529"
       }
@@ -369,20 +369,20 @@
   },
   "menu-item-background-color-disabled": {
     "component": "menu-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "211d6540-cf9d-4d80-815b-885844283fa6"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-200}",
         "uuid": "0e2c2900-180c-443a-86ff-49170166e616"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-100}",
         "uuid": "5924d0c5-6938-4660-8be3-9374bb3e5b0c"
       }
@@ -390,20 +390,20 @@
   },
   "popover-border-color": {
     "component": "popover",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{transparent-white-25}",
         "uuid": "66da6f53-5446-43c1-bbe0-73b46763fde1"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-400}",
         "uuid": "825dc035-7b1c-4ddd-b1a9-be1546dae7e3"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-200}",
         "uuid": "92133ef4-9b81-4fbd-9736-8b83078ef053"
       }
@@ -411,20 +411,20 @@
   },
   "popover-border-opacity": {
     "component": "popover",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
         "value": "0",
         "uuid": "05c58363-1d34-4991-a7f7-7be7da4df50a"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
         "value": "1.0",
         "uuid": "fa9feacc-0c82-41a7-badc-5803c45a703b"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
         "value": "0",
         "uuid": "55ab7957-997f-41a7-b31d-0994a2f77859"
       }
@@ -432,104 +432,104 @@
   },
   "coach-indicator-color": {
     "component": "coach-indicator",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{blue-800}",
     "uuid": "bfd387b8-0ce0-45ff-8d66-fc5de2f4900c"
   },
   "swatch-group-border-color": {
     "component": "swatch-group",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-1000}",
     "uuid": "08b8d06a-5475-47bf-ad2e-9f52ee07345a"
   },
   "avatar-border-color": {
     "component": "avatar",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-25}",
     "uuid": "bae79ea7-2b3e-4d43-af42-7deab67acc7c"
   },
   "standard-panel-gripper-color-drag": {
     "component": "standard-panel",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-800}",
     "uuid": "69e2d0b3-6807-4e46-9f8a-72bf49439f36"
   },
   "standard-panel-gripper-color": {
     "component": "standard-panel",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-200}",
     "uuid": "71840c7b-acdd-45b9-a228-5091591f5405"
   },
   "bar-panel-gripper-color": {
     "component": "bar-panel",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-200}",
     "uuid": "5a46c025-32b4-4bda-bab0-5ab0fb69ca8e"
   },
   "bar-panel-gripper-color-drag": {
     "component": "bar-panel",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-800}",
     "uuid": "16431c28-23e4-4077-bcfa-138f90583282"
   },
   "select-box-selected-border-color": {
     "component": "select-box",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-800}",
     "uuid": "4bbb81b1-09fb-4ebe-80b5-cebb75c13839"
   },
   "tree-view-row-background-hover": {
     "component": "tree-view",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-100}",
     "uuid": "39d26185-da40-47b5-b4b3-e47689129256"
   },
   "tree-view-selected-row-background-color-emphasized": {
     "component": "tree-view",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{informative-background-color-default}",
     "uuid": "65854450-ed1a-49ea-ab29-d257b8a0569e"
   },
   "tree-view-selected-row-background-default": {
     "component": "tree-view",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-100}",
     "uuid": "8f19994d-f49a-42ea-97bd-98ab1d76d02d"
   },
   "tree-view-selected-row-background-hover": {
     "component": "tree-view",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-100}",
     "uuid": "c325ed8f-8248-40c3-a0f0-efba57638f24"
   },
   "color-wheel-border-color": {
     "component": "color-wheel",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-1000}",
     "uuid": "a60c3946-dff7-4245-bdcd-b61445066e48"
   },
   "color-wheel-border-opacity": {
     "component": "color-wheel",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/opacity.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
     "uuid": "be8fac27-b644-492e-a89d-6c87cfecb8a1"
   },
   "action-bar-border-color": {
     "component": "action-bar",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color-set.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
     "sets": {
       "light": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{transparent-white-25}",
         "uuid": "166159cc-9353-4d22-90f0-64718533d73a"
       },
       "dark": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{gray-400}",
         "uuid": "dac0d761-d8c1-4b1f-bfbe-766651122ecf"
       },
       "wireframe": {
-        "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
         "value": "{transparent-white-25}",
         "uuid": "e242c2e1-54db-40c5-98ee-abebdcd59f4d"
       }
@@ -537,61 +537,61 @@
   },
   "card-background-well-color": {
     "component": "card",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-100}",
     "uuid": "c9c0e684-6b6c-4314-9b5b-7ba5e3333071"
   },
   "card-background-loading-color": {
     "component": "card",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-100}",
     "uuid": "6022f845-b182-493f-bdae-f86f6336efaa"
   },
   "stack-item-background-color-hover": {
     "component": "stack-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-100}",
     "uuid": "022a6244-ce6c-4c3f-82a1-e2f5118d3c5e"
   },
   "stack-item-background-color-down": {
     "component": "stack-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-100}",
     "uuid": "c99360a4-de28-48e6-80ad-93adb714d388"
   },
   "stack-item-background-color-key-focus": {
     "component": "stack-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-100}",
     "uuid": "a0251da6-7517-4712-85a1-29ca7f16ef91"
   },
   "stack-item-selected-background-color-default": {
     "component": "stack-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-100}",
     "uuid": "128c4963-471a-44e3-9fb5-328d92d0266d"
   },
   "stack-item-selected-background-color-hover": {
     "component": "stack-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-200}",
     "uuid": "a1bcd6c6-ef3e-42e4-8d88-2fafe2b318da"
   },
   "stack-item-selected-background-color-down": {
     "component": "stack-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-200}",
     "uuid": "1ad58d16-66da-44ae-829e-9ee1ff56a857"
   },
   "stack-item-selected-background-color-key-focus": {
     "component": "stack-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{gray-200}",
     "uuid": "93f433f2-2d0b-4225-8b39-b10000808360"
   },
   "stack-item-selected-background-color-emphasized": {
     "component": "stack-item",
-    "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{accent-background-color-default}",
     "uuid": "95685612-09b7-477f-9c13-06eb58abe5c8"
   }

--- a/packages/tokens/test/schemaValidators/alias.test.js
+++ b/packages/tokens/test/schemaValidators/alias.test.js
@@ -30,7 +30,7 @@ test("Every token schema should validate against the definition", (t) => {
   const alias = {
     component: "swatch",
     $schema:
-      "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
+      "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     value: "{gray-900}",
     uuid: "7da5157d-7f25-405b-8de0-f3669565fb48",
   };

--- a/templates/node-tool/package.json
+++ b/templates/node-tool/package.json
@@ -7,12 +7,12 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/adobe/spectrum-tokens.git"
+    "url": "git+https://github.com/adobe/spectrum-design-data.git"
   },
   "author": "Garth Braithwaite <garthdb@gmail.com> (http://garthdb.com/)",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/adobe/spectrum-tokens/issues"
+    "url": "https://github.com/adobe/spectrum-design-data/issues"
   },
-  "homepage": "https://github.com/adobe/spectrum-tokens#readme"
+  "homepage": "https://github.com/adobe/spectrum-design-data#readme"
 }


### PR DESCRIPTION
## Summary

This PR renames the repository from `spectrum-tokens` to `spectrum-design-data` to better reflect that this monorepo contains more than just design tokens.

## Changes Made

### Repository References Updated
- ✅ All `package.json` files updated with new repository URLs
- ✅ Main `README.md` updated to reference new repository
- ✅ Documentation in `docs/visualizer/README.md` updated
- ✅ Schema URLs updated to new hosted location
- ✅ Test files updated with new schema references

### NPM Package Names Preserved
- ✅ `@adobe/spectrum-tokens` package name unchanged
- ✅ `@adobe/spectrum-component-api-schemas` package name unchanged
- ✅ Full backward compatibility maintained for consumers

### Files Updated
- `package.json` (root)
- `README.md` (root) 
- `packages/tokens/package.json`
- `packages/component-schemas/package.json`
- `templates/node-tool/package.json`
- `docs/visualizer/README.md`
- `packages/tokens/src/color-component.json` (schema URLs)
- `packages/tokens/test/schemaValidators/alias.test.js` (schema URLs)
- `.changeset/rename-repository.md` (new changeset)

## Breaking Changes

⚠️ **Repository URL Change**: The repository will be accessible at `github.com/adobe/spectrum-design-data` instead of `github.com/adobe/spectrum-tokens`.

**Note**: NPM package names remain unchanged to avoid breaking existing consumers.

## Testing

- [ ] Verify all links work after repository rename
- [ ] Confirm npm packages can still be published
- [ ] Validate schema URLs resolve correctly after deployment

## Historical Note

Historical changelog entries that reference the old repository name in commit/PR URLs are intentionally preserved for historical accuracy.