### PR TITLE
feat(tooling): add design data MCP servers for enhanced development workflow

### DIFF
--- a/.changeset/spectrum-design-data-mcp-initial.md
+++ b/.changeset/spectrum-design-data-mcp-initial.md
@@ -1,0 +1,17 @@
+---
+"@adobe/spectrum-design-data-mcp": major
+---
+
+Initial release of Spectrum Design Data MCP server
+
+This is the first release of the Model Context Protocol server that provides AI tools with structured access to Adobe Spectrum design system data, including design tokens and component API schemas.
+
+Features:
+
+- Query design tokens by name, type, or category
+- Find tokens for specific component use cases
+- Get component-specific token recommendations
+- Access component API schemas and validation
+- Type definitions and schema validation tools
+
+This enables AI assistants to provide intelligent design guidance and automate design token usage across the Spectrum ecosystem.

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -6,8 +6,10 @@
     "ava Docs": {
       "url": "https://gitmcp.io/avajs/ava"
     },
-    "moon Docs": {
-      "url": "https://gitmcp.io/moonrepo/moon"
+    "moon": {
+      "command": "moon",
+      "args": ["mcp"],
+      "cwd": "${workspaceFolder}"
     },
     "handlebars.js Docs": {
       "url": "https://gitmcp.io/handlebars-lang/handlebars.js"
@@ -23,6 +25,11 @@
     },
     "nixt Docs": {
       "url": "https://gitmcp.io/vesln/nixt"
+    },
+    "spectrum-design-data": {
+      "command": "node",
+      "args": ["tools/spectrum-design-data-mcp/src/cli.js"],
+      "cwd": "${workspaceFolder}"
     }
   }
 }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -25,11 +25,6 @@
     },
     "nixt Docs": {
       "url": "https://gitmcp.io/vesln/nixt"
-    },
-    "spectrum-design-data": {
-      "command": "node",
-      "args": ["tools/spectrum-design-data-mcp/src/cli.js"],
-      "cwd": "${workspaceFolder}"
     }
   }
 }

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -14,6 +14,7 @@ projects:
   viewer: "docs/s2-tokens-viewer"
   release-analyzer: "tools/release-analyzer"
   release-timeline: "docs/release-timeline"
+  spectrum-design-data-mcp: "tools/spectrum-design-data-mcp"
 vcs:
   manager: "git"
   defaultBranch: "main"

--- a/README.md
+++ b/README.md
@@ -15,11 +15,29 @@ This repo uses:
 
 Packages in this monorepo:
 
+## Core Packages
+
 - [Spectrum Tokens](packages/tokens/) design tokens for Spectrum, Adobe's design system.
-- [Spectrum Token Visualizer Tool](docs/visualizer/) a visualizer for inspecting tokens. Published as a [static site](https://opensource.adobe.com/spectrum-tokens/visualizer/), not an NPM package.
+- [Spectrum Component Schemas](packages/component-schemas/) JSON schemas for validating Spectrum component APIs and properties.
+
+## Documentation & Visualization
+
+- [Spectrum Token Visualizer Tool](docs/visualizer/) a visualizer for inspecting S1 tokens. Published as a [static site](https://opensource.adobe.com/spectrum-tokens/visualizer/).
 - [Spectrum Token Visualizer Tool S2](docs/s2-visualizer/) a version of the visualizer that shows the Spectrum 2 data. Published as a [static site](https://opensource.adobe.com/spectrum-tokens/s2-visualizer/).
+- [Spectrum S2 Tokens Viewer](docs/s2-tokens-viewer/) an enhanced token viewer with component usage analysis for Spectrum 2 tokens.
 - [Spectrum Tokens Docs](docs/site/) a static site to show the component options API and other token data.
+- [Release Timeline Visualization](docs/release-timeline/) interactive charts showing release frequency and development activity patterns. Published as a [static site](https://opensource.adobe.com/spectrum-tokens/release-timeline/).
+
+## Development Tools
+
 - [Spectrum Token Diff Generator](tools/diff-generator/) a library and cli tool that reports changes made between two schema/releases/branches.
+- [Optimized Diff Engine](tools/optimized-diff/) high-performance diff algorithm for large token datasets.
+- [Release Analyzer](tools/release-analyzer/) tool for analyzing release history and generating data for change frequency visualization.
+- [Token Changeset Generator](tools/token-changeset-generator/) automates creation of changeset files from token diff analysis.
+- [Token CSV Generator](tools/token-csv-generator/) exports token data to CSV format for analysis and reporting.
+- [Transform Tokens JSON](tools/transform-tokens-json/) utilities for merging and transforming token data between formats.
+- [Token Manifest Builder](tools/token-manifest-builder/) generates manifest files for token distribution.
+- [Spectrum Design Data MCP](tools/spectrum-design-data-mcp/) Model Context Protocol server providing AI assistants with structured access to Spectrum design system data.
 
 ## Setup monorepo locally
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,25 @@ importers:
         specifier: ^6.0.0
         version: 6.4.0(rollup@4.44.1)
 
+  tools/spectrum-design-data-mcp:
+    dependencies:
+      "@adobe/spectrum-component-api-schemas":
+        specifier: workspace:*
+        version: link:../../packages/component-schemas
+      "@adobe/spectrum-tokens":
+        specifier: workspace:*
+        version: link:../../packages/tokens
+      "@modelcontextprotocol/sdk":
+        specifier: ^0.5.0
+        version: 0.5.0
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
+    devDependencies:
+      ava:
+        specifier: ^6.0.1
+        version: 6.4.0(rollup@4.44.1)
+
   tools/token-changeset-generator:
     dependencies:
       "@adobe/token-diff-generator":
@@ -1054,6 +1073,12 @@ packages:
       }
     engines: { node: ">=18" }
     hasBin: true
+
+  "@modelcontextprotocol/sdk@0.5.0":
+    resolution:
+      {
+        integrity: sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==,
+      }
 
   "@moonrepo/cli@1.39.1":
     resolution:
@@ -2005,6 +2030,13 @@ packages:
       }
     engines: { node: ">=10.16.0" }
 
+  bytes@3.1.2:
+    resolution:
+      {
+        integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==,
+      }
+    engines: { node: ">= 0.8" }
+
   c8@10.1.3:
     resolution:
       {
@@ -2274,6 +2306,13 @@ packages:
       {
         integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==,
       }
+
+  content-type@1.0.5:
+    resolution:
+      {
+        integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==,
+      }
+    engines: { node: ">= 0.6" }
 
   conventional-changelog-angular@7.0.0:
     resolution:
@@ -2637,6 +2676,13 @@ packages:
       {
         integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==,
       }
+
+  depd@2.0.0:
+    resolution:
+      {
+        integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==,
+      }
+    engines: { node: ">= 0.8" }
 
   detect-indent@6.1.0:
     resolution:
@@ -3209,6 +3255,13 @@ packages:
         integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
       }
 
+  http-errors@2.0.0:
+    resolution:
+      {
+        integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==,
+      }
+    engines: { node: ">= 0.8" }
+
   https-proxy-agent@7.0.6:
     resolution:
       {
@@ -3299,6 +3352,12 @@ packages:
         integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==,
       }
     engines: { node: ">=12" }
+
+  inherits@2.0.4:
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
 
   ini@4.1.1:
     resolution:
@@ -4318,6 +4377,13 @@ packages:
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
       }
 
+  raw-body@3.0.0:
+    resolution:
+      {
+        integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==,
+      }
+    engines: { node: ">= 0.8" }
+
   react-dom@18.3.1:
     resolution:
       {
@@ -4469,6 +4535,12 @@ packages:
       }
     engines: { node: ">=10" }
 
+  setprototypeof@1.2.0:
+    resolution:
+      {
+        integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
+      }
+
   shebang-command@2.0.0:
     resolution:
       {
@@ -4577,6 +4649,13 @@ packages:
         integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==,
       }
     engines: { node: ">=10" }
+
+  statuses@2.0.1:
+    resolution:
+      {
+        integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   streamsearch@1.1.0:
     resolution:
@@ -4793,6 +4872,13 @@ packages:
       }
     engines: { node: ">=8.0" }
 
+  toidentifier@1.0.1:
+    resolution:
+      {
+        integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==,
+      }
+    engines: { node: ">=0.6" }
+
   tr46@0.0.3:
     resolution:
       {
@@ -4889,6 +4975,13 @@ packages:
         integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==,
       }
     engines: { node: ">= 10.0.0" }
+
+  unpipe@1.0.0:
+    resolution:
+      {
+        integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   upper-case-first@2.0.2:
     resolution:
@@ -5087,6 +5180,12 @@ packages:
         integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==,
       }
     engines: { node: ">=12.20" }
+
+  zod@3.25.76:
+    resolution:
+      {
+        integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
+      }
 
 snapshots:
   "@action-validator/core@0.6.0": {}
@@ -5584,6 +5683,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  "@modelcontextprotocol/sdk@0.5.0":
+    dependencies:
+      content-type: 1.0.5
+      raw-body: 3.0.0
+      zod: 3.25.76
 
   "@moonrepo/cli@1.39.1":
     dependencies:
@@ -6167,6 +6272,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  bytes@3.1.2: {}
+
   c8@10.1.3:
     dependencies:
       "@bcoe/v8-coverage": 1.0.2
@@ -6328,6 +6435,8 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
       upper-case: 2.0.2
+
+  content-type@1.0.5: {}
 
   conventional-changelog-angular@7.0.0:
     dependencies:
@@ -6551,6 +6660,8 @@ snapshots:
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
+
+  depd@2.0.0: {}
 
   detect-indent@6.1.0: {}
 
@@ -6921,6 +7032,14 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
@@ -6958,6 +7077,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@5.0.0: {}
+
+  inherits@2.0.4: {}
 
   ini@4.1.1: {}
 
@@ -7466,6 +7587,13 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      unpipe: 1.0.0
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -7563,6 +7691,8 @@ snapshots:
     dependencies:
       type-fest: 0.13.1
 
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -7612,6 +7742,8 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  statuses@2.0.1: {}
 
   streamsearch@1.1.0: {}
 
@@ -7735,6 +7867,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tr46@0.0.3: {}
 
   tslib@2.8.1: {}
@@ -7765,6 +7899,8 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
 
   upper-case-first@2.0.2:
     dependencies:
@@ -7863,3 +7999,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  zod@3.25.76: {}

--- a/tools/spectrum-design-data-mcp/CHANGELOG.md
+++ b/tools/spectrum-design-data-mcp/CHANGELOG.md
@@ -1,0 +1,31 @@
+# @adobe/spectrum-design-data-mcp
+
+## 0.2.0
+
+### Minor Changes
+
+- Initial release of Spectrum Design Data MCP server
+
+  This new package provides a Model Context Protocol (MCP) server that enables AI tools to query and interact with Spectrum design system data. Features include:
+  - **Design Token Tools**: Query tokens by name, type, or category; get token details and categories
+  - **Component Schema Tools**: Search component schemas, validate properties, and explore type definitions
+  - **Local Execution**: Runs as a local npm package with no external dependencies or hosting requirements
+  - **Extensible Architecture**: Designed to support future design data like component anatomy and patterns
+
+  The MCP server provides structured access to:
+  - All Spectrum design tokens from `@adobe/spectrum-tokens`
+  - Component API schemas from `@adobe/spectrum-component-api-schemas`
+
+  AI assistants can now understand and work with Spectrum design data through standardized MCP tools.
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release of Spectrum Design Data MCP server
+- Added support for design token querying and retrieval
+- Added support for component schema validation and exploration
+- Implemented token tools: query-tokens, get-token-categories, get-token-details
+- Implemented schema tools: query-component-schemas, get-component-schema, list-components, validate-component-props, get-type-schemas
+- Added CLI interface for starting the MCP server
+- Added comprehensive test coverage

--- a/tools/spectrum-design-data-mcp/README.md
+++ b/tools/spectrum-design-data-mcp/README.md
@@ -1,0 +1,190 @@
+# Spectrum Design Data MCP Server
+
+A Model Context Protocol (MCP) server that provides AI tools with structured access to Adobe Spectrum design system data, including design tokens and component API schemas.
+
+## Overview
+
+This MCP server enables AI assistants to query and interact with Spectrum design data through a standardized protocol. It provides access to:
+
+- **Design Tokens**: Color palettes, typography, layout tokens, and semantic tokens
+- **Component Schemas**: API definitions and validation schemas for Spectrum components
+- **Future**: Component anatomy, design patterns, and guidelines
+
+## Installation
+
+```bash
+npm install -g @adobe/spectrum-design-data-mcp
+```
+
+## Usage
+
+### Starting the MCP Server
+
+```bash
+# Start the server (default command)
+spectrum-design-data-mcp
+
+# Or explicitly start
+spectrum-design-data-mcp start
+```
+
+The server runs locally and communicates via stdio with MCP-compatible AI clients.
+
+### Available Tools
+
+#### Token Tools
+
+- **`query-tokens`**: Search and retrieve design tokens by name, type, or category
+- **`find-tokens-by-use-case`** ⭐: Find appropriate tokens for specific component use cases (e.g., "button background", "text color", "error state")
+- **`get-component-tokens`** ⭐: Get all tokens related to a specific component type
+- **`get-design-recommendations`** ⭐: Get token recommendations for design decisions and component states
+- **`get-token-categories`**: List all available token categories
+- **`get-token-details`**: Get detailed information about a specific token
+
+#### Schema Tools
+
+- **`query-component-schemas`**: Search component API schemas
+- **`get-component-schema`**: Get the complete schema for a specific component
+- **`list-components`**: List all available components with schemas
+- **`validate-component-props`**: Validate component properties against schemas
+- **`get-type-schemas`**: Get type definitions used in schemas
+
+## Configuration with AI Clients
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "spectrum-design-data": {
+      "command": "spectrum-design-data-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Other MCP Clients
+
+The server uses stdio transport and follows the MCP specification. Refer to your client's documentation for configuration details.
+
+## Examples
+
+### Component Building Workflow ⭐
+
+#### Finding Tokens for Component Use Cases
+
+```
+Human: I'm building a primary action button. What design tokens should I use for the background color?
+
+AI: I'll help you find the appropriate tokens for a primary button background.
+
+[Uses find-tokens-by-use-case with useCase="button background" and componentType="button"]
+
+For a primary action button background, I recommend these Spectrum tokens:
+- accent-color-100: Primary accent color for default state
+- accent-color-200: For hover states
+- accent-color-300: For pressed/active states
+- floating-action-button-drop-shadow-color: For drop shadows
+```
+
+#### Design Intent Recommendations
+
+```
+Human: What tokens should I use for error messaging in my form validation?
+
+AI: I'll find tokens for error state messaging.
+
+[Uses get-design-recommendations with intent="negative" and context="text"]
+
+For error messaging, use these Spectrum tokens:
+- negative-color-100: Primary error text color
+- negative-background-color-default: Error background areas
+- negative-border-color: Error state borders
+```
+
+#### Component-Specific Token Discovery
+
+```
+Human: Show me all available button-related design tokens.
+
+AI: I'll gather all button-related tokens from the Spectrum system.
+
+[Uses get-component-tokens with componentName="button"]
+
+Found 57 button-related tokens across categories:
+- Color tokens (2): floating-action-button colors
+- Layout tokens (55): button sizing, padding, spacing
+- Examples: radio-button-control-size-small, action-button-edge-to-hold-icon...
+```
+
+### Traditional Token Queries
+
+#### Querying Color Tokens
+
+```
+Human: What blue color tokens are available in Spectrum?
+
+AI: I'll search for blue color tokens in the Spectrum design system.
+
+[Uses query-tokens tool with query="blue" and category="color"]
+
+The Spectrum design system includes several blue color tokens:
+- spectrum-blue-100: #e6f3ff
+- spectrum-blue-200: #b3d9ff
+- spectrum-blue-300: #80bfff
+...
+```
+
+#### Validating Component Props
+
+```
+Human: Is this button configuration valid according to Spectrum?
+
+AI: I'll validate those button properties against the Spectrum schema.
+
+[Uses validate-component-props tool with component="action-button"]
+
+The configuration is valid! All required properties are present and the types match the expected schema.
+```
+
+## Development
+
+### Building from Source
+
+```bash
+git clone https://github.com/adobe/spectrum-tokens.git
+cd spectrum-tokens
+pnpm install
+cd tools/spectrum-design-data-mcp
+```
+
+### Testing
+
+```bash
+pnpm test
+```
+
+### Project Structure
+
+```
+src/
+├── index.js              # Main MCP server
+├── cli.js               # CLI interface
+├── tools/               # MCP tool implementations
+│   ├── tokens.js        # Token-related tools
+│   └── schemas.js       # Schema-related tools
+└── data/                # Data access layer
+    ├── tokens.js        # Token data access
+    └── schemas.js       # Schema data access
+```
+
+## License
+
+Apache-2.0 © Adobe
+
+## Contributing
+
+This project is part of the Spectrum Design System. Please see the main [contribution guidelines](../../CONTRIBUTING.md) for details on how to contribute.

--- a/tools/spectrum-design-data-mcp/ava.config.js
+++ b/tools/spectrum-design-data-mcp/ava.config.js
@@ -1,0 +1,7 @@
+export default {
+  files: ["test/**/*.test.js"],
+  verbose: true,
+  environmentVariables: {
+    NODE_ENV: "test",
+  },
+};

--- a/tools/spectrum-design-data-mcp/moon.yml
+++ b/tools/spectrum-design-data-mcp/moon.yml
@@ -1,0 +1,37 @@
+# Copyright 2024 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+$schema: "https://moonrepo.dev/schemas/project.json"
+layer: tool
+tasks:
+  start:
+    command:
+      - node
+      - src/cli.js
+      - start
+    platform: node
+  test:
+    command:
+      - pnpm
+      - ava
+    platform: node
+  test-watch:
+    command:
+      - ava
+      - --watch
+      - c8
+      - ava
+    local: true
+    platform: node
+  version:
+    command:
+      - node
+      - update-version.js
+    local: true
+    platform: node

--- a/tools/spectrum-design-data-mcp/package.json
+++ b/tools/spectrum-design-data-mcp/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@adobe/spectrum-design-data-mcp",
+  "version": "0.2.0",
+  "description": "Model Context Protocol server for Spectrum design data including tokens, schemas, and component anatomy",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "spectrum",
+    "design-tokens",
+    "component-schemas",
+    "component-anatomy",
+    "design-data",
+    "design-system",
+    "adobe",
+    "ai-tools"
+  ],
+  "type": "module",
+  "main": "./src/index.js",
+  "bin": {
+    "spectrum-design-data-mcp": "./src/cli.js"
+  },
+  "files": [
+    "src/",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "ava"
+  },
+  "engines": {
+    "node": ">=20.12.0",
+    "pnpm": ">=10.11.0"
+  },
+  "packageManager": "pnpm@10.11.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/spectrum-tokens.git",
+    "directory": "tools/spectrum-design-data-mcp"
+  },
+  "author": "Garth Braithwaite <garthdb@gmail.com> (http://garthdb.com/)",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-tokens/issues"
+  },
+  "homepage": "https://github.com/adobe/spectrum-tokens/tree/main/tools/spectrum-design-data-mcp#readme",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "dependencies": {
+    "@adobe/spectrum-tokens": "workspace:*",
+    "@adobe/spectrum-component-api-schemas": "workspace:*",
+    "@modelcontextprotocol/sdk": "^0.5.0",
+    "commander": "^13.1.0"
+  },
+  "devDependencies": {
+    "ava": "^6.0.1"
+  }
+}

--- a/tools/spectrum-design-data-mcp/src/cli.js
+++ b/tools/spectrum-design-data-mcp/src/cli.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Command } from "commander";
+import { startServer } from "./index.js";
+
+const program = new Command();
+
+program
+  .name("spectrum-design-data-mcp")
+  .description("Model Context Protocol server for Spectrum design data")
+  .version("0.1.0");
+
+program
+  .command("start")
+  .description("Start the MCP server with stdio transport")
+  .action(async () => {
+    try {
+      await startServer();
+    } catch (error) {
+      console.error("Failed to start MCP server:", error);
+      process.exit(1);
+    }
+  });
+
+// If no command is provided, default to start
+if (process.argv.length === 2) {
+  process.argv.push("start");
+}
+
+program.parse();

--- a/tools/spectrum-design-data-mcp/src/data/schemas.js
+++ b/tools/spectrum-design-data-mcp/src/data/schemas.js
@@ -1,0 +1,150 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Get schema data from the component-schemas package
+ * @returns {Promise<Object>} Schema data organized by type
+ */
+export async function getSchemaData() {
+  try {
+    // Try to import from the workspace package first
+    const componentSchemas = await import(
+      "@adobe/spectrum-component-api-schemas"
+    );
+
+    // If the package exports schema data directly, use it
+    if (componentSchemas.default || componentSchemas.schemas) {
+      return componentSchemas.default || componentSchemas.schemas;
+    }
+
+    // Otherwise, read the schema files directly from the package
+    return await loadSchemaFilesDirectly();
+  } catch (error) {
+    console.error(
+      "Failed to load schema data from package, trying direct file access:",
+      error,
+    );
+    return await loadSchemaFilesDirectly();
+  }
+}
+
+/**
+ * Load schema files directly from the repository structure
+ * @returns {Promise<Object>} Schema data
+ */
+async function loadSchemaFilesDirectly() {
+  const schemaData = {
+    components: {},
+    types: {},
+  };
+
+  // Path to the schemas directory
+  const schemasPath = join(
+    __dirname,
+    "../../../../packages/component-schemas/schemas",
+  );
+
+  // Load component schemas
+  const componentsPath = join(schemasPath, "components");
+  try {
+    const componentFiles = readdirSync(componentsPath).filter((file) =>
+      file.endsWith(".json"),
+    );
+
+    for (const fileName of componentFiles) {
+      try {
+        const filePath = join(componentsPath, fileName);
+        const fileContent = readFileSync(filePath, "utf8");
+        schemaData.components[fileName] = JSON.parse(fileContent);
+      } catch (error) {
+        console.error(`Failed to load component schema ${fileName}:`, error);
+      }
+    }
+  } catch (error) {
+    console.error("Failed to read components directory:", error);
+  }
+
+  // Load type schemas
+  const typesPath = join(schemasPath, "types");
+  try {
+    const typeFiles = readdirSync(typesPath).filter((file) =>
+      file.endsWith(".json"),
+    );
+
+    for (const fileName of typeFiles) {
+      try {
+        const filePath = join(typesPath, fileName);
+        const fileContent = readFileSync(filePath, "utf8");
+        schemaData.types[fileName] = JSON.parse(fileContent);
+      } catch (error) {
+        console.error(`Failed to load type schema ${fileName}:`, error);
+      }
+    }
+  } catch (error) {
+    console.error("Failed to read types directory:", error);
+  }
+
+  return schemaData;
+}
+
+/**
+ * Get available component names
+ * @returns {Promise<Array<string>>} List of component names
+ */
+export async function getComponentNames() {
+  const schemaData = await getSchemaData();
+  return Object.keys(schemaData.components).map((fileName) =>
+    fileName.replace(".json", ""),
+  );
+}
+
+/**
+ * Get schema for a specific component
+ * @param {string} componentName - Component name
+ * @returns {Promise<Object|null>} Component schema
+ */
+export async function getComponentSchema(componentName) {
+  const schemaData = await getSchemaData();
+  const fileName = componentName.endsWith(".json")
+    ? componentName
+    : `${componentName}.json`;
+  return schemaData.components[fileName] || null;
+}
+
+/**
+ * Get available type names
+ * @returns {Promise<Array<string>>} List of type names
+ */
+export async function getTypeNames() {
+  const schemaData = await getSchemaData();
+  return Object.keys(schemaData.types).map((fileName) =>
+    fileName.replace(".json", ""),
+  );
+}
+
+/**
+ * Get schema for a specific type
+ * @param {string} typeName - Type name
+ * @returns {Promise<Object|null>} Type schema
+ */
+export async function getTypeSchema(typeName) {
+  const schemaData = await getSchemaData();
+  const fileName = typeName.endsWith(".json") ? typeName : `${typeName}.json`;
+  return schemaData.types[fileName] || null;
+}

--- a/tools/spectrum-design-data-mcp/src/data/tokens.js
+++ b/tools/spectrum-design-data-mcp/src/data/tokens.js
@@ -1,0 +1,111 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Get token data from the spectrum-tokens package
+ * @returns {Promise<Object>} Token data organized by category
+ */
+export async function getTokenData() {
+  try {
+    // Try to import from the workspace package first
+    const spectrumTokens = await import("@adobe/spectrum-tokens");
+
+    // If the package exports token data directly, use it
+    if (spectrumTokens.default || spectrumTokens.tokens) {
+      return spectrumTokens.default || spectrumTokens.tokens;
+    }
+
+    // Otherwise, read the token files directly from the package
+    return await loadTokenFilesFromPackage();
+  } catch (error) {
+    console.error(
+      "Failed to load token data from package, trying direct file access:",
+      error,
+    );
+    return await loadTokenFilesDirectly();
+  }
+}
+
+/**
+ * Load token files from the spectrum-tokens package structure
+ * @returns {Promise<Object>} Token data
+ */
+async function loadTokenFilesFromPackage() {
+  // This would be the ideal approach - loading from the actual package
+  // For now, we'll fall back to direct file access
+  return await loadTokenFilesDirectly();
+}
+
+/**
+ * Load token files directly from the repository structure
+ * @returns {Promise<Object>} Token data
+ */
+async function loadTokenFilesDirectly() {
+  const tokenData = {};
+
+  // Path to the tokens source directory
+  const tokensPath = join(__dirname, "../../../../packages/tokens/src");
+
+  // List of token files to load
+  const tokenFiles = [
+    "color-aliases.json",
+    "color-component.json",
+    "color-palette.json",
+    "icons.json",
+    "layout-component.json",
+    "layout.json",
+    "semantic-color-palette.json",
+    "typography.json",
+  ];
+
+  for (const fileName of tokenFiles) {
+    try {
+      const filePath = join(tokensPath, fileName);
+      const fileContent = readFileSync(filePath, "utf8");
+      tokenData[fileName] = JSON.parse(fileContent);
+    } catch (error) {
+      console.error(`Failed to load token file ${fileName}:`, error);
+      // Continue loading other files even if one fails
+    }
+  }
+
+  return tokenData;
+}
+
+/**
+ * Get available token categories
+ * @returns {Promise<Array<string>>} List of token categories
+ */
+export async function getTokenCategories() {
+  const tokenData = await getTokenData();
+  return Object.keys(tokenData).map((fileName) =>
+    fileName.replace(".json", ""),
+  );
+}
+
+/**
+ * Get tokens from a specific category
+ * @param {string} category - Token category name
+ * @returns {Promise<Object|null>} Token data for the category
+ */
+export async function getTokensByCategory(category) {
+  const tokenData = await getTokenData();
+  const fileName = category.endsWith(".json") ? category : `${category}.json`;
+  return tokenData[fileName] || null;
+}

--- a/tools/spectrum-design-data-mcp/src/index.js
+++ b/tools/spectrum-design-data-mcp/src/index.js
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { createTokenTools } from "./tools/tokens.js";
+import { createSchemaTools } from "./tools/schemas.js";
+
+/**
+ * Create and configure the Spectrum Design Data MCP server
+ * @returns {Server} Configured MCP server instance
+ */
+export function createMCPServer() {
+  const server = new Server(
+    {
+      name: "spectrum-design-data",
+      version: "0.1.0",
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  // Combine all available tools
+  const allTools = [...createTokenTools(), ...createSchemaTools()];
+
+  // Register list_tools handler
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: allTools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      })),
+    };
+  });
+
+  // Register call_tool handler
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    const tool = allTools.find((t) => t.name === name);
+    if (!tool) {
+      throw new Error(`Tool not found: ${name}`);
+    }
+
+    try {
+      const result = await tool.handler(args || {});
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              typeof result === "string"
+                ? result
+                : JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      throw new Error(`Tool execution failed: ${error.message}`);
+    }
+  });
+
+  return server;
+}
+
+/**
+ * Start the MCP server with stdio transport
+ */
+export async function startServer() {
+  const server = createMCPServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // Log server start for debugging (this goes to stderr, not stdout which is used for MCP)
+  console.error("Spectrum Design Data MCP server started");
+}
+
+// Export for testing
+export { createTokenTools, createSchemaTools };

--- a/tools/spectrum-design-data-mcp/src/tools/schemas.js
+++ b/tools/spectrum-design-data-mcp/src/tools/schemas.js
@@ -1,0 +1,472 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { getSchemaData } from "../data/schemas.js";
+
+/**
+ * Create schema-related MCP tools
+ * @returns {Array} Array of schema tools
+ */
+export function createSchemaTools() {
+  return [
+    {
+      name: "query-component-schemas",
+      description: "Search and retrieve Spectrum component API schemas",
+      inputSchema: {
+        type: "object",
+        properties: {
+          component: {
+            type: "string",
+            description:
+              'Component name to search for (e.g., "button", "action-button")',
+          },
+          query: {
+            type: "string",
+            description:
+              "Search query to filter schemas (searches component names, descriptions)",
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of schemas to return (default: 20)",
+            default: 20,
+          },
+        },
+      },
+      handler: async (args) => {
+        const { component, query, limit = 20 } = args;
+        const schemaData = await getSchemaData();
+
+        let results = [];
+
+        // Search through component schemas
+        for (const [fileName, schema] of Object.entries(
+          schemaData.components,
+        )) {
+          const componentName = fileName.replace(".json", "");
+
+          // Apply component filter
+          if (component && !componentName.includes(component.toLowerCase())) {
+            continue;
+          }
+
+          // Apply query filter
+          if (query && !matchesSchemaQuery(componentName, schema, query)) {
+            continue;
+          }
+
+          results.push({
+            component: componentName,
+            fileName,
+            title: schema.title,
+            description: schema.description,
+            properties: Object.keys(schema.properties || {}),
+            required: schema.required || [],
+            schema,
+          });
+        }
+
+        // Apply limit
+        results = results.slice(0, limit);
+
+        return {
+          total: results.length,
+          schemas: results,
+          query: { component, query, limit },
+        };
+      },
+    },
+    {
+      name: "get-component-schema",
+      description: "Get the complete schema for a specific component",
+      inputSchema: {
+        type: "object",
+        properties: {
+          component: {
+            type: "string",
+            description: 'Component name (e.g., "action-button")',
+            required: true,
+          },
+        },
+        required: ["component"],
+      },
+      handler: async (args) => {
+        const { component } = args;
+        const schemaData = await getSchemaData();
+
+        const fileName = `${component}.json`;
+        const schema = schemaData.components[fileName];
+
+        if (!schema) {
+          throw new Error(`Component schema not found: ${component}`);
+        }
+
+        return {
+          component,
+          schema,
+          metadata: {
+            title: schema.title,
+            description: schema.description,
+            propertyCount: Object.keys(schema.properties || {}).length,
+            requiredCount: (schema.required || []).length,
+          },
+        };
+      },
+    },
+    {
+      name: "list-components",
+      description: "List all available Spectrum components with schemas",
+      inputSchema: {
+        type: "object",
+        properties: {},
+      },
+      handler: async () => {
+        const schemaData = await getSchemaData();
+
+        const components = Object.keys(schemaData.components).map(
+          (fileName) => {
+            const componentName = fileName.replace(".json", "");
+            const schema = schemaData.components[fileName];
+
+            return {
+              name: componentName,
+              title: schema.title,
+              description: schema.description,
+              propertyCount: Object.keys(schema.properties || {}).length,
+              hasRequired: (schema.required || []).length > 0,
+            };
+          },
+        );
+
+        return {
+          total: components.length,
+          components: components.sort((a, b) => a.name.localeCompare(b.name)),
+        };
+      },
+    },
+    {
+      name: "validate-component-props",
+      description: "Validate component properties against their schema",
+      inputSchema: {
+        type: "object",
+        properties: {
+          component: {
+            type: "string",
+            description: "Component name to validate against",
+            required: true,
+          },
+          props: {
+            type: "object",
+            description: "Component properties to validate",
+            required: true,
+          },
+        },
+        required: ["component", "props"],
+      },
+      handler: async (args) => {
+        const { component, props } = args;
+        const schemaData = await getSchemaData();
+
+        const fileName = `${component}.json`;
+        const schema = schemaData.components[fileName];
+
+        if (!schema) {
+          throw new Error(`Component schema not found: ${component}`);
+        }
+
+        // Basic validation logic
+        const validationResults = validateProps(props, schema);
+
+        return {
+          component,
+          valid: validationResults.valid,
+          errors: validationResults.errors,
+          warnings: validationResults.warnings,
+          props,
+        };
+      },
+    },
+    {
+      name: "get-type-schemas",
+      description: "Get type definitions used in component schemas",
+      inputSchema: {
+        type: "object",
+        properties: {
+          type: {
+            type: "string",
+            description: 'Specific type to retrieve (e.g., "hex-color")',
+          },
+        },
+      },
+      handler: async (args) => {
+        const { type } = args;
+        const schemaData = await getSchemaData();
+
+        if (type) {
+          const typeSchema = schemaData.types[`${type}.json`];
+          if (!typeSchema) {
+            throw new Error(`Type schema not found: ${type}`);
+          }
+
+          return {
+            type,
+            schema: typeSchema,
+          };
+        }
+
+        // Return all types
+        const types = Object.keys(schemaData.types).map((fileName) => {
+          const typeName = fileName.replace(".json", "");
+          const typeSchema = schemaData.types[fileName];
+
+          return {
+            name: typeName,
+            title: typeSchema.title,
+            description: typeSchema.description,
+            type: typeSchema.type,
+          };
+        });
+
+        return {
+          total: types.length,
+          types: types.sort((a, b) => a.name.localeCompare(b.name)),
+        };
+      },
+    },
+    {
+      name: "get-component-options",
+      description:
+        "Get all available options/properties for a component in a user-friendly format - perfect for discovering what options a component supports",
+      inputSchema: {
+        type: "object",
+        properties: {
+          component: {
+            type: "string",
+            description:
+              'Component name (e.g., "action-button", "text-field", "menu")',
+            required: true,
+          },
+          detailed: {
+            type: "boolean",
+            description:
+              "Include detailed property information like enums, default values, etc.",
+            default: false,
+          },
+        },
+        required: ["component"],
+      },
+      handler: async (args) => {
+        const { component, detailed = false } = args;
+        const schemaData = await getSchemaData();
+
+        const fileName = `${component}.json`;
+        const schema = schemaData.components[fileName];
+
+        if (!schema) {
+          throw new Error(
+            `Component not found: ${component}. Use list-components to see available components.`,
+          );
+        }
+
+        const componentInfo = {
+          name: component,
+          title: schema.title || component,
+          description: schema.description,
+          totalProperties: 0,
+          properties: [],
+        };
+
+        if (schema.properties) {
+          componentInfo.totalProperties = Object.keys(schema.properties).length;
+
+          Object.entries(schema.properties).forEach(([propName, propDef]) => {
+            const propInfo = {
+              name: propName,
+              type: propDef.type || "object",
+              required: schema.required
+                ? schema.required.includes(propName)
+                : false,
+              description: propDef.description,
+            };
+
+            if (detailed) {
+              // Add detailed information
+              if (propDef.enum) {
+                propInfo.possibleValues = propDef.enum;
+              }
+              if (propDef.default !== undefined) {
+                propInfo.defaultValue = propDef.default;
+              }
+              if (propDef.properties) {
+                propInfo.nestedProperties = Object.keys(propDef.properties);
+              }
+              if (propDef.$ref) {
+                propInfo.reference = propDef.$ref;
+              }
+            }
+
+            componentInfo.properties.push(propInfo);
+          });
+
+          // Sort properties: required first, then alphabetical
+          componentInfo.properties.sort((a, b) => {
+            if (a.required !== b.required) return a.required ? -1 : 1;
+            return a.name.localeCompare(b.name);
+          });
+        }
+
+        return componentInfo;
+      },
+    },
+    {
+      name: "search-components-by-feature",
+      description:
+        'Find components that have specific features or properties (e.g., "size", "disabled", "selected")',
+      inputSchema: {
+        type: "object",
+        properties: {
+          feature: {
+            type: "string",
+            description:
+              'The feature/property to search for (e.g., "size", "disabled", "icon", "label")',
+            required: true,
+          },
+        },
+        required: ["feature"],
+      },
+      handler: async (args) => {
+        const { feature } = args;
+        const schemaData = await getSchemaData();
+        const matchingComponents = [];
+
+        Object.entries(schemaData.components).forEach(([fileName, schema]) => {
+          const componentName = fileName.replace(".json", "");
+
+          if (schema.properties) {
+            const hasFeature = Object.keys(schema.properties).some((prop) =>
+              prop.toLowerCase().includes(feature.toLowerCase()),
+            );
+
+            if (hasFeature) {
+              const matchingProps = Object.keys(schema.properties).filter(
+                (prop) => prop.toLowerCase().includes(feature.toLowerCase()),
+              );
+
+              matchingComponents.push({
+                name: componentName,
+                title: schema.title || componentName,
+                description: schema.description,
+                matchingProperties: matchingProps,
+                totalProperties: Object.keys(schema.properties).length,
+              });
+            }
+          }
+        });
+
+        return {
+          feature,
+          totalMatches: matchingComponents.length,
+          components: matchingComponents.sort((a, b) =>
+            a.name.localeCompare(b.name),
+          ),
+        };
+      },
+    },
+  ];
+}
+
+/**
+ * Check if a schema matches the search query
+ * @param {string} componentName - Component name
+ * @param {Object} schema - Schema object
+ * @param {string} query - Search query
+ * @returns {boolean} Whether the schema matches
+ */
+function matchesSchemaQuery(componentName, schema, query) {
+  const searchText = query.toLowerCase();
+
+  // Search in component name
+  if (componentName.toLowerCase().includes(searchText)) {
+    return true;
+  }
+
+  // Search in title
+  if (schema.title && schema.title.toLowerCase().includes(searchText)) {
+    return true;
+  }
+
+  // Search in description
+  if (
+    schema.description &&
+    schema.description.toLowerCase().includes(searchText)
+  ) {
+    return true;
+  }
+
+  // Search in property names
+  if (schema.properties) {
+    for (const propName of Object.keys(schema.properties)) {
+      if (propName.toLowerCase().includes(searchText)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Basic validation of properties against schema
+ * @param {Object} props - Properties to validate
+ * @param {Object} schema - Schema to validate against
+ * @returns {Object} Validation results
+ */
+function validateProps(props, schema) {
+  const errors = [];
+  const warnings = [];
+
+  // Check required properties
+  const required = schema.required || [];
+  for (const requiredProp of required) {
+    if (!(requiredProp in props)) {
+      errors.push(`Missing required property: ${requiredProp}`);
+    }
+  }
+
+  // Check property types (basic validation)
+  const schemaProps = schema.properties || {};
+  for (const [propName, propValue] of Object.entries(props)) {
+    const propSchema = schemaProps[propName];
+
+    if (!propSchema) {
+      warnings.push(`Unknown property: ${propName}`);
+      continue;
+    }
+
+    // Basic type checking
+    if (propSchema.type) {
+      const expectedType = propSchema.type;
+      const actualType = Array.isArray(propValue) ? "array" : typeof propValue;
+
+      if (expectedType !== actualType) {
+        errors.push(
+          `Property ${propName} should be ${expectedType}, got ${actualType}`,
+        );
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}

--- a/tools/spectrum-design-data-mcp/src/tools/tokens.js
+++ b/tools/spectrum-design-data-mcp/src/tools/tokens.js
@@ -1,0 +1,581 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { getTokenData } from "../data/tokens.js";
+
+/**
+ * Create token-related MCP tools
+ * @returns {Array} Array of token tools
+ */
+export function createTokenTools() {
+  return [
+    {
+      name: "query-tokens",
+      description:
+        "Search and retrieve Spectrum design tokens by name, type, or category",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Search query to filter tokens (searches names, types, categories)",
+          },
+          category: {
+            type: "string",
+            description:
+              'Filter by token category (e.g., "color", "layout", "typography")',
+          },
+          type: {
+            type: "string",
+            description: 'Filter by token type (e.g., "alias", "component")',
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of tokens to return (default: 50)",
+            default: 50,
+          },
+        },
+      },
+      handler: async (args) => {
+        const { query, category, type, limit = 50 } = args;
+        const tokenData = await getTokenData();
+
+        let results = [];
+
+        // Search through all token files
+        for (const [fileName, tokens] of Object.entries(tokenData)) {
+          // Skip if category filter doesn't match
+          if (
+            category &&
+            !fileName.toLowerCase().includes(category.toLowerCase())
+          ) {
+            continue;
+          }
+
+          // Process tokens based on their structure
+          const processedTokens = processTokens(tokens, fileName, query, type);
+          results.push(...processedTokens);
+        }
+
+        // Apply limit
+        results = results.slice(0, limit);
+
+        return {
+          total: results.length,
+          tokens: results,
+          query: { query, category, type, limit },
+        };
+      },
+    },
+    {
+      name: "get-token-categories",
+      description:
+        "Get all available token categories in the Spectrum design system",
+      inputSchema: {
+        type: "object",
+        properties: {},
+      },
+      handler: async () => {
+        const tokenData = await getTokenData();
+        const categories = Object.keys(tokenData).map((fileName) => {
+          // Extract category from filename (e.g., "color-palette.json" -> "color-palette")
+          return fileName.replace(".json", "");
+        });
+
+        return {
+          categories,
+          total: categories.length,
+        };
+      },
+    },
+    {
+      name: "get-token-details",
+      description:
+        "Get detailed information about a specific token by its path",
+      inputSchema: {
+        type: "object",
+        properties: {
+          tokenPath: {
+            type: "string",
+            description: 'The full path to the token (e.g., "color.blue.100")',
+            required: true,
+          },
+          category: {
+            type: "string",
+            description: 'Token category to search in (e.g., "color-palette")',
+          },
+        },
+        required: ["tokenPath"],
+      },
+      handler: async (args) => {
+        const { tokenPath, category } = args;
+        const tokenData = await getTokenData();
+
+        // Search for the token in all categories or specific category
+        const categoriesToSearch = category
+          ? [category]
+          : Object.keys(tokenData);
+
+        for (const cat of categoriesToSearch) {
+          const categoryData = tokenData[cat + ".json"] || tokenData[cat];
+          if (!categoryData) continue;
+
+          const token = findTokenByPath(categoryData, tokenPath);
+          if (token) {
+            return {
+              path: tokenPath,
+              category: cat,
+              token,
+            };
+          }
+        }
+
+        throw new Error(`Token not found: ${tokenPath}`);
+      },
+    },
+    {
+      name: "find-tokens-by-use-case",
+      description:
+        'Find appropriate design tokens for specific component use cases (e.g., "button background", "text color", "border", "spacing")',
+      inputSchema: {
+        type: "object",
+        properties: {
+          useCase: {
+            type: "string",
+            description:
+              'The use case or purpose (e.g., "button background", "text color", "border", "spacing", "error state")',
+          },
+          componentType: {
+            type: "string",
+            description:
+              'Optional: Type of component being built (e.g., "button", "input", "card")',
+          },
+        },
+        required: ["useCase"],
+      },
+      handler: async ({ useCase, componentType }) => {
+        const data = await getTokenData();
+        const recommendations = [];
+
+        // Smart token recommendations based on use case
+        const useCaseLower = useCase.toLowerCase();
+        const compTypeLower = (componentType || "").toLowerCase();
+
+        // Define use case mappings
+        const useCasePatterns = {
+          background: [
+            "color-component",
+            "semantic-color-palette",
+            "color-palette",
+          ],
+          text: ["color-component", "semantic-color-palette", "typography"],
+          border: ["color-component", "semantic-color-palette"],
+          spacing: ["layout", "layout-component"],
+          padding: ["layout", "layout-component"],
+          margin: ["layout", "layout-component"],
+          font: ["typography"],
+          icon: ["icons", "layout"],
+          error: ["semantic-color-palette", "color-component"],
+          success: ["semantic-color-palette", "color-component"],
+          warning: ["semantic-color-palette", "color-component"],
+          accent: ["semantic-color-palette", "color-component"],
+          button: ["color-component", "layout-component"],
+          input: ["color-component", "layout-component"],
+          card: ["color-component", "layout-component"],
+        };
+
+        // Find relevant categories
+        const relevantCategories = [];
+        for (const [pattern, categories] of Object.entries(useCasePatterns)) {
+          if (
+            useCaseLower.includes(pattern) ||
+            compTypeLower.includes(pattern)
+          ) {
+            relevantCategories.push(...categories);
+          }
+        }
+
+        // If no specific patterns match, search all categories
+        const categoriesToSearch =
+          relevantCategories.length > 0
+            ? [...new Set(relevantCategories)]
+            : Object.keys(data);
+
+        // Search within relevant categories
+        for (const category of categoriesToSearch) {
+          const filename = category.includes(".json")
+            ? category
+            : `${category}.json`;
+          const tokens = data[filename];
+          if (!tokens) continue;
+
+          Object.entries(tokens).forEach(([name, token]) => {
+            const nameMatch =
+              name.toLowerCase().includes(useCaseLower) ||
+              (componentType && name.toLowerCase().includes(compTypeLower));
+            const descMatch =
+              token.description &&
+              token.description.toLowerCase().includes(useCaseLower);
+
+            if (nameMatch || descMatch) {
+              recommendations.push({
+                name,
+                category: filename,
+                value: token.value,
+                description: token.description,
+                schema: token.$schema,
+                uuid: token.uuid,
+                private: token.private || false,
+                relevanceReason: nameMatch ? "name match" : "description match",
+              });
+            }
+          });
+        }
+
+        // Sort by relevance (non-private first, then by name match)
+        recommendations.sort((a, b) => {
+          if (a.private !== b.private) return a.private ? 1 : -1;
+          if (a.relevanceReason !== b.relevanceReason) {
+            return a.relevanceReason === "name match" ? -1 : 1;
+          }
+          return a.name.localeCompare(b.name);
+        });
+
+        return {
+          useCase,
+          componentType,
+          recommendations: recommendations.slice(0, 20), // Limit to top 20
+          totalFound: recommendations.length,
+          searchedCategories: categoriesToSearch,
+        };
+      },
+    },
+    {
+      name: "get-component-tokens",
+      description: "Get all tokens related to a specific component type",
+      inputSchema: {
+        type: "object",
+        properties: {
+          componentName: {
+            type: "string",
+            description:
+              'Name of the component (e.g., "button", "input", "card", "modal")',
+          },
+        },
+        required: ["componentName"],
+      },
+      handler: async ({ componentName }) => {
+        const data = await getTokenData();
+        const componentTokens = [];
+        const componentLower = componentName.toLowerCase();
+
+        // Search through all token categories for component-specific tokens
+        Object.entries(data).forEach(([category, tokens]) => {
+          if (!tokens) return;
+
+          Object.entries(tokens).forEach(([name, token]) => {
+            if (name.toLowerCase().includes(componentLower)) {
+              componentTokens.push({
+                name,
+                category,
+                value: token.value,
+                description: token.description,
+                schema: token.$schema,
+                uuid: token.uuid,
+                private: token.private || false,
+              });
+            }
+          });
+        });
+
+        // Group by category for better organization
+        const groupedTokens = componentTokens.reduce((acc, token) => {
+          if (!acc[token.category]) acc[token.category] = [];
+          acc[token.category].push(token);
+          return acc;
+        }, {});
+
+        return {
+          componentName,
+          tokensByCategory: groupedTokens,
+          totalTokens: componentTokens.length,
+        };
+      },
+    },
+    {
+      name: "get-design-recommendations",
+      description:
+        "Get design token recommendations for common design decisions and component states",
+      inputSchema: {
+        type: "object",
+        properties: {
+          intent: {
+            type: "string",
+            description:
+              'Design intent (e.g., "primary", "secondary", "accent", "negative", "notice", "positive", "informative")',
+          },
+          state: {
+            type: "string",
+            description:
+              'Component state (e.g., "default", "hover", "focus", "active", "disabled", "selected")',
+          },
+          context: {
+            type: "string",
+            description:
+              'Usage context (e.g., "button", "input", "text", "background", "border", "icon")',
+          },
+        },
+        required: ["intent"],
+      },
+      handler: async ({ intent, state, context }) => {
+        const data = await getTokenData();
+        const recommendations = {
+          colors: [],
+          layout: [],
+          typography: [],
+        };
+
+        const intentLower = intent.toLowerCase();
+        const stateLower = (state || "").toLowerCase();
+        const contextLower = (context || "").toLowerCase();
+
+        // Search semantic colors first (these are typically the best recommendations)
+        const semanticColors = data["semantic-color-palette.json"] || {};
+        Object.entries(semanticColors).forEach(([name, token]) => {
+          const nameLower = name.toLowerCase();
+
+          // Intent matching
+          const intentMatch =
+            nameLower.includes(intentLower) ||
+            (intentLower === "error" && nameLower.includes("negative")) ||
+            (intentLower === "success" && nameLower.includes("positive")) ||
+            (intentLower === "warning" && nameLower.includes("notice"));
+
+          // State matching
+          const stateMatch = !state || nameLower.includes(stateLower);
+
+          // Context matching
+          const contextMatch = !context || nameLower.includes(contextLower);
+
+          if (intentMatch && stateMatch && contextMatch) {
+            recommendations.colors.push({
+              name,
+              value: token.value,
+              category: "semantic-color-palette",
+              type: "semantic",
+              confidence: "high",
+            });
+          }
+        });
+
+        // Search component colors if semantic colors don't provide enough options
+        if (recommendations.colors.length < 3) {
+          const componentColors = data["color-component.json"] || {};
+          Object.entries(componentColors).forEach(([name, token]) => {
+            const nameLower = name.toLowerCase();
+
+            // Intent and context matching for component colors
+            const intentMatch = nameLower.includes(intentLower);
+            const contextMatch = !context || nameLower.includes(contextLower);
+            const stateMatch = !state || nameLower.includes(stateLower);
+
+            if ((intentMatch || contextMatch) && stateMatch) {
+              recommendations.colors.push({
+                name,
+                value: token.value,
+                category: "color-component",
+                type: "component",
+                confidence: "medium",
+              });
+            }
+          });
+        }
+
+        // Layout recommendations if context suggests spacing/sizing
+        if (
+          context &&
+          ["button", "input", "spacing", "padding", "margin"].some((c) =>
+            contextLower.includes(c),
+          )
+        ) {
+          const layoutComponent = data["layout-component.json"] || {};
+          Object.entries(layoutComponent).forEach(([name, token]) => {
+            const nameLower = name.toLowerCase();
+
+            if (
+              contextLower &&
+              nameLower.includes(contextLower) &&
+              nameLower.includes(stateLower || "size")
+            ) {
+              recommendations.layout.push({
+                name,
+                value: token.value,
+                category: "layout-component",
+                type: "spacing",
+                confidence: "high",
+              });
+            }
+          });
+        }
+
+        // Typography recommendations for text contexts
+        if (
+          context &&
+          ["text", "label", "heading", "body"].some((c) =>
+            contextLower.includes(c),
+          )
+        ) {
+          const typography = data["typography.json"] || {};
+          Object.entries(typography).forEach(([name, token]) => {
+            const nameLower = name.toLowerCase();
+
+            if (nameLower.includes(contextLower)) {
+              recommendations.typography.push({
+                name,
+                value: token.value,
+                category: "typography",
+                type: "text",
+                confidence: "high",
+              });
+            }
+          });
+        }
+
+        // Sort by confidence and limit results
+        ["colors", "layout", "typography"].forEach((category) => {
+          recommendations[category] = recommendations[category]
+            .sort((a, b) => {
+              const confidenceOrder = { high: 0, medium: 1, low: 2 };
+              return (
+                confidenceOrder[a.confidence] - confidenceOrder[b.confidence]
+              );
+            })
+            .slice(0, 10);
+        });
+
+        return {
+          intent,
+          state,
+          context,
+          recommendations,
+          totalFound:
+            recommendations.colors.length +
+            recommendations.layout.length +
+            recommendations.typography.length,
+        };
+      },
+    },
+  ];
+}
+
+/**
+ * Process tokens based on search criteria
+ * @param {Object} tokens - Token data structure
+ * @param {string} fileName - Name of the token file
+ * @param {string} query - Search query
+ * @param {string} type - Type filter
+ * @returns {Array} Processed tokens
+ */
+function processTokens(tokens, fileName, query, type) {
+  const results = [];
+  const category = fileName.replace(".json", "");
+
+  function traverse(obj, path = "") {
+    for (const [key, value] of Object.entries(obj)) {
+      const currentPath = path ? `${path}.${key}` : key;
+
+      if (value && typeof value === "object") {
+        if (value.$value !== undefined || value.value !== undefined) {
+          // This is a token
+          const tokenType = value.$type || value.type || "unknown";
+
+          // Apply type filter
+          if (type && tokenType !== type) {
+            continue;
+          }
+
+          // Apply query filter
+          if (query && !matchesQuery(currentPath, value, query)) {
+            continue;
+          }
+
+          results.push({
+            name: key,
+            path: currentPath,
+            category,
+            type: tokenType,
+            value: value.$value || value.value,
+            description: value.$description || value.description,
+            extensions: value.$extensions || value.extensions,
+          });
+        } else {
+          // Recurse into nested objects
+          traverse(value, currentPath);
+        }
+      }
+    }
+  }
+
+  traverse(tokens);
+  return results;
+}
+
+/**
+ * Find a token by its path
+ * @param {Object} tokens - Token data structure
+ * @param {string} path - Token path (e.g., "color.blue.100")
+ * @returns {Object|null} Token object or null if not found
+ */
+function findTokenByPath(tokens, path) {
+  const parts = path.split(".");
+  let current = tokens;
+
+  for (const part of parts) {
+    if (current[part] === undefined) {
+      return null;
+    }
+    current = current[part];
+  }
+
+  return current;
+}
+
+/**
+ * Check if a token matches the search query
+ * @param {string} path - Token path
+ * @param {Object} token - Token object
+ * @param {string} query - Search query
+ * @returns {boolean} Whether the token matches
+ */
+function matchesQuery(path, token, query) {
+  const searchText = query.toLowerCase();
+
+  // Search in path
+  if (path.toLowerCase().includes(searchText)) {
+    return true;
+  }
+
+  // Search in description
+  const description = token.$description || token.description || "";
+  if (description.toLowerCase().includes(searchText)) {
+    return true;
+  }
+
+  // Search in value (for string values)
+  const value = token.$value || token.value || "";
+  if (typeof value === "string" && value.toLowerCase().includes(searchText)) {
+    return true;
+  }
+
+  return false;
+}

--- a/tools/spectrum-design-data-mcp/test/index.test.js
+++ b/tools/spectrum-design-data-mcp/test/index.test.js
@@ -1,0 +1,27 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import test from "ava";
+import { createMCPServer } from "../src/index.js";
+
+test("MCP server initializes correctly", (t) => {
+  const server = createMCPServer();
+  t.truthy(server);
+  t.is(typeof server, "object");
+});
+
+test("MCP server has correct name and version", (t) => {
+  const server = createMCPServer();
+  // Note: The Server class internals may not expose these directly
+  // This test verifies the server was created successfully
+  t.truthy(server);
+});

--- a/tools/spectrum-design-data-mcp/test/tools/schemas.test.js
+++ b/tools/spectrum-design-data-mcp/test/tools/schemas.test.js
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import test from "ava";
+import { createSchemaTools } from "../../src/tools/schemas.js";
+
+test("createSchemaTools returns array of tools", (t) => {
+  const tools = createSchemaTools();
+  t.true(Array.isArray(tools));
+  t.true(tools.length > 0);
+});
+
+test("schema tools have required properties", (t) => {
+  const tools = createSchemaTools();
+
+  for (const tool of tools) {
+    t.is(typeof tool.name, "string");
+    t.is(typeof tool.description, "string");
+    t.is(typeof tool.inputSchema, "object");
+    t.is(typeof tool.handler, "function");
+  }
+});
+
+test("query-component-schemas tool exists", (t) => {
+  const tools = createSchemaTools();
+  const queryTool = tools.find(
+    (tool) => tool.name === "query-component-schemas",
+  );
+
+  t.truthy(queryTool);
+  t.is(queryTool.name, "query-component-schemas");
+  t.true(queryTool.description.includes("Search"));
+});
+
+test("get-component-schema tool exists", (t) => {
+  const tools = createSchemaTools();
+  const schemaTool = tools.find((tool) => tool.name === "get-component-schema");
+
+  t.truthy(schemaTool);
+  t.is(schemaTool.name, "get-component-schema");
+  t.true(schemaTool.inputSchema.required.includes("component"));
+});
+
+test("list-components tool exists", (t) => {
+  const tools = createSchemaTools();
+  const listTool = tools.find((tool) => tool.name === "list-components");
+
+  t.truthy(listTool);
+  t.is(listTool.name, "list-components");
+});
+
+test("validate-component-props tool exists", (t) => {
+  const tools = createSchemaTools();
+  const validateTool = tools.find(
+    (tool) => tool.name === "validate-component-props",
+  );
+
+  t.truthy(validateTool);
+  t.is(validateTool.name, "validate-component-props");
+  t.true(validateTool.inputSchema.required.includes("component"));
+  t.true(validateTool.inputSchema.required.includes("props"));
+});
+
+test("get-type-schemas tool exists", (t) => {
+  const tools = createSchemaTools();
+  const typesTool = tools.find((tool) => tool.name === "get-type-schemas");
+
+  t.truthy(typesTool);
+  t.is(typesTool.name, "get-type-schemas");
+});

--- a/tools/spectrum-design-data-mcp/test/tools/tokens.test.js
+++ b/tools/spectrum-design-data-mcp/test/tools/tokens.test.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import test from "ava";
+import { createTokenTools } from "../../src/tools/tokens.js";
+
+test("createTokenTools returns array of tools", (t) => {
+  const tools = createTokenTools();
+  t.true(Array.isArray(tools));
+  t.true(tools.length > 0);
+});
+
+test("token tools have required properties", (t) => {
+  const tools = createTokenTools();
+
+  for (const tool of tools) {
+    t.is(typeof tool.name, "string");
+    t.is(typeof tool.description, "string");
+    t.is(typeof tool.inputSchema, "object");
+    t.is(typeof tool.handler, "function");
+  }
+});
+
+test("query-tokens tool exists", (t) => {
+  const tools = createTokenTools();
+  const queryTool = tools.find((tool) => tool.name === "query-tokens");
+
+  t.truthy(queryTool);
+  t.is(queryTool.name, "query-tokens");
+  t.true(queryTool.description.includes("Search"));
+});
+
+test("get-token-categories tool exists", (t) => {
+  const tools = createTokenTools();
+  const categoriesTool = tools.find(
+    (tool) => tool.name === "get-token-categories",
+  );
+
+  t.truthy(categoriesTool);
+  t.is(categoriesTool.name, "get-token-categories");
+});
+
+test("get-token-details tool exists", (t) => {
+  const tools = createTokenTools();
+  const detailsTool = tools.find((tool) => tool.name === "get-token-details");
+
+  t.truthy(detailsTool);
+  t.is(detailsTool.name, "get-token-details");
+  t.true(detailsTool.inputSchema.required.includes("tokenPath"));
+});


### PR DESCRIPTION
## Description

Enhanced the MCP (Model Context Protocol) configuration by adding several new documentation servers to improve development workflow and access to tool-specific documentation.

## Related Issue

This change supports the ongoing spectrum-design-data-mcp tool development and improves developer experience by providing direct access to documentation for commonly used tools in the project.

## Motivation and Context

The addition of these MCP servers addresses the need for:
- Better access to tool documentation during development
- Improved developer productivity through contextual help
- Streamlined workflow for working with various tools in the spectrum-tokens ecosystem

New MCP servers added:
- changesets Docs: For version management and changelog generation
- ava Docs: For testing framework documentation  
- handlebars.js Docs: For template engine documentation
- pnpm Docs: For package management documentation
- commitlint Docs: For commit message linting guidance
- GitHub CLI Docs: For GitHub CLI command reference
- nixt Docs: For CLI testing framework documentation

## How Has This Been Tested?

- Verified MCP configuration syntax is valid JSON
- Confirmed all server URLs are accessible
- Tested that the configuration doesn't break existing MCP functionality

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the Adobe Open Source CLA
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly  
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed