### PR TITLE
fix(release): commit release timeline data instead of built site files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      - name: Commit updated release timeline
+      - name: Commit updated release timeline data
         if: steps.changesets.outputs.published == 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add site/release-timeline/
-          git diff --staged --quiet || git commit -m "chore: update release timeline visualization data
+          git add docs/release-timeline/public/data/releases.json
+          git diff --staged --quiet || git commit -m "chore: update release timeline data
 
           Updated release timeline data following release of ${{ steps.changesets.outputs.publishedPackages }}"
           git push


### PR DESCRIPTION
## Description

Fixes the release workflow failure that occurred when trying to commit files in the `/site` directory which is properly ignored by `.gitignore`.

## Problem

The release workflow was failing with:


This happened because the workflow tried to commit built site files from `site/release-timeline/` which are correctly ignored since they are build artifacts.

## Solution

Changed the workflow to commit the source data file instead:
- **Before**: `git add site/release-timeline/` (ignored directory)
- **After**: `git add docs/release-timeline/public/data/releases.json` (source data file)

This approach:
- ✅ Preserves the release timeline data in git for historical tracking
- ✅ Avoids conflicts with `.gitignore` 
- ✅ Separates concerns: data is committed, built site is deployed separately
- ✅ The built site deployment continues to work via the existing `deploy-docs.yml` workflow

## Testing

The recent release of `@adobe/spectrum-design-data-mcp@1.0.0` succeeded in publishing the package but failed on this post-publish step. With this fix, future releases will complete successfully.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed