### PR TITLE
fix(ci): handle empty diff output correctly in generate-diff action

### DIFF
--- a/.github/actions/generate-diff/action.yml
+++ b/.github/actions/generate-diff/action.yml
@@ -93,8 +93,12 @@ runs:
           echo "diff_content<<EOF" >> $GITHUB_OUTPUT
           cat "${{ inputs.output-file }}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+        elif [ $exit_code -eq 0 ] && [ -f "${{ inputs.output-file }}" ]; then
+          # Command succeeded but file exists but is empty (no changes)
+          echo "diff_generated=false" >> $GITHUB_OUTPUT
+          echo "diff_content=No changes detected." >> $GITHUB_OUTPUT
         elif [ $exit_code -eq 0 ]; then
-          # Command succeeded but no changes detected
+          # Command succeeded but no output file created
           echo "diff_generated=false" >> $GITHUB_OUTPUT
           echo "diff_content=No changes detected." >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
# Fix GitHub Actions Output Error for Empty Diff Reports

## Problem
The changeset release PR (#583) is failing with:


## Root Cause
When the component diff generator runs on the changeset release branch, it correctly reports "No component schema changes detected" and creates an empty output file. However, the GitHub Actions workflow tries to use EOF delimiters for multiline output even when the file is empty, causing the delimiter parsing to fail.

## Solution
- Add proper handling for when diff command succeeds but generates no changes
- Prevent EOF delimiter errors when output file exists but is empty  
- Distinguish between empty file and missing file cases
- Use simple single-line output for "No changes detected" case

## Impact
- ✅ Fixes failing tests in changeset release PR #583
- ✅ Prevents similar failures in future component diff workflows
- ✅ Maintains correct behavior for actual diff content

This is a critical fix needed to unblock the release process.