### PR TITLE
SDS-15337: Standard panel gripper color update

### DIFF
--- a/.changeset/24aeff17e430.md
+++ b/.changeset/24aeff17e430.md
@@ -1,0 +1,15 @@
+---
+"@adobe/spectrum-tokens": patch
+---
+
+SDS-15337: Standard panel gripper color update
+
+Source: [spectrum-tokens-studio-data#283](https://github.com/adobe/spectrum-tokens-studio-data/pull/283)
+Author: @mrcjhicks
+
+## Token Changes
+
+### Updated (1)
+
+- `standard-panel-gripper-color`
+  - `value`: `{gray-200}` -> `{gray-500}`

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -457,7 +457,7 @@
   "standard-panel-gripper-color": {
     "component": "standard-panel",
     "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/alias.json",
-    "value": "{gray-200}",
+    "value": "{gray-500}",
     "uuid": "71840c7b-acdd-45b9-a228-5091591f5405"
   },
   "bar-panel-gripper-color": {

--- a/tools/component-diff-generator/src/cli.js
+++ b/tools/component-diff-generator/src/cli.js
@@ -20,9 +20,12 @@ import { fileURLToPath } from "url";
 
 import componentDiff from "./lib/component-diff.js";
 import { ComponentLoader } from "./lib/component-file-import.js";
-import packageJson from "../package.json" with { type: "json" };
+import { readFileSync } from "fs";
 
 const red = chalk.hex("F37E7E");
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
 const { version } = packageJson;
 
 const __filename = fileURLToPath(import.meta.url);

--- a/tools/diff-generator/src/lib/cli.js
+++ b/tools/diff-generator/src/lib/cli.js
@@ -18,9 +18,12 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { HandlebarsFormatter } from "./formatterHandlebars.js";
 import storeOutput from "./store-output.js";
-import packageJson from "../../package.json" with { type: "json" };
+import { readFileSync } from "fs";
 
 const red = chalk.hex("F37E7E");
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+);
 const { version } = packageJson;
 
 // ===== PHASE 1: PURE UTILITY FUNCTIONS (easily testable) =====

--- a/tools/token-changeset-generator/src/cli.js
+++ b/tools/token-changeset-generator/src/cli.js
@@ -14,7 +14,11 @@ governing permissions and limitations under the License.
 
 import { Command } from "commander";
 import { generateTokenChangeset } from "./index.js";
-import packageJson from "../package.json" with { type: "json" };
+import { readFileSync } from "fs";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
 
 const program = new Command();
 


### PR DESCRIPTION
## Token Updates from Spectrum Tokens Studio Data

**Source PR**: [#283 SDS-15337: Standard panel gripper color update](https://github.com/adobe/spectrum-tokens-studio-data/pull/283)

**Automated sync via**: [GitHub Actions Run](https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/17330507087)

---

Created by Action: https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/17330507087
